### PR TITLE
Fixes #42 (Explicit client commits should be optional)

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -526,11 +526,11 @@ public class WARCIndexer {
 	 * @param firstDate
 	 * @return
 	 */
-	private String getYearFromDate(Date date) {
-		Calendar c = Calendar.getInstance();
-		c.setTime(date);
-		return ""+c.get(Calendar.YEAR);
+	private synchronized String getYearFromDate(Date date) {
+		calendar.setTime(date);
+		return Integer.toString(calendar.get(Calendar.YEAR));
 	}
+    private final Calendar calendar = Calendar.getInstance();
 
 	/* ----------------------------------- */
 


### PR DESCRIPTION
Added command line option with unchanged default behaviour (commit before each (W)ARC file as well af after all (W)ARC files).