### PR TITLE
Performance instrumentation

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
@@ -40,6 +40,7 @@ import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
 
 import com.typesafe.config.Config;
+import uk.bl.wa.util.Instrument;
 
 /**
  * @author anj
@@ -72,6 +73,7 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 	 * @param solr
 	 */
 	public void analyse(ArchiveRecordHeader header, InputStream tikainput, SolrRecord solr) {
+        final long start = System.nanoTime();
 		Metadata metadata = new Metadata();
 		HashMap<String, String> hosts = new HashMap<String, String>();
 		HashMap<String, String> suffixes = new HashMap<String, String>();
@@ -142,6 +144,7 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 		for( String lurl : metadata.getValues( Metadata.LICENSE_URL ) ) {
 			solr.addField( SolrFields.LICENSE_URL, lurl );
 		}
-	}
+        Instrument.timeRel("HTMLAnalyzer.analyze", start);
+    }
 	
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
@@ -92,7 +92,7 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 			log.error( "WritableSolrRecord.extract(): " + e.getMessage() );
 			solr.addParseException("when parsing as HTML", e);
 		}
-        Instrument.timeRel("HTMLAnalyzer.analyze#parser", start);
+        Instrument.timeRel("HTMLAnalyzer.analyze#total", "HTMLAnalyzer.analyze#parser", start);
 
 		// Process links:
 		String links_list = metadata.get( HtmlFeatureParser.LINK_LIST );
@@ -142,7 +142,7 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 		for( String lurl : metadata.getValues( Metadata.LICENSE_URL ) ) {
 			solr.addField( SolrFields.LICENSE_URL, lurl );
 		}
-        Instrument.timeRel("HTMLAnalyzer.analyze#total", start);
+        Instrument.timeRel("WARCPayloadAnalyzers.analyze#total", "HTMLAnalyzer.analyze#total", start);
     }
 	
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
@@ -26,8 +26,8 @@ package uk.bl.wa.analyser.payload;
  */
 
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Iterator;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -72,12 +72,13 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 	 * @param tikainput
 	 * @param solr
 	 */
-	public void analyse(ArchiveRecordHeader header, InputStream tikainput, SolrRecord solr) {
+	@Override
+    public void analyse(ArchiveRecordHeader header, InputStream tikainput, SolrRecord solr) {
         final long start = System.nanoTime();
 		Metadata metadata = new Metadata();
-		HashMap<String, String> hosts = new HashMap<String, String>();
-		HashMap<String, String> suffixes = new HashMap<String, String>();
-		HashMap<String, String> domains = new HashMap<String, String>();
+		Set<String> hosts = new HashSet<String>();
+		Set<String> suffixes = new HashSet<String>();
+		Set<String> domains = new HashSet<String>();
 		
 		// JSoup NEEDS the URL to function:
 		metadata.set( Metadata.RESOURCE_NAME_KEY, header.getUrl() );
@@ -91,6 +92,7 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 			log.error( "WritableSolrRecord.extract(): " + e.getMessage() );
 			solr.addParseException("when parsing as HTML", e);
 		}
+        Instrument.timeRel("HTMLAnalyzer.analyze#parser", start);
 
 		// Process links:
 		String links_list = metadata.get( HtmlFeatureParser.LINK_LIST );
@@ -99,37 +101,33 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 			for( String link : links_list.split( " " ) ) {
 				lhost = LinkExtractor.extractHost( link );
 				if( !lhost.equals( LinkExtractor.MALFORMED_HOST ) ) {
-					hosts.put( lhost, "" );
+					hosts.add(lhost);
 				}
 				lsuffix = LinkExtractor.extractPublicSuffix( link );
 				if( lsuffix != null ) {
-					suffixes.put( lsuffix, "" );
+					suffixes.add(lsuffix);
 				}
 				ldomain = LinkExtractor.extractPrivateSuffix( link );
 				if( ldomain != null ) {
-					domains.put( ldomain, "" );
+					domains.add(ldomain);
 				}
 				// Also store actual resource-level links:
 				if( this.extractLinks )
 					solr.addField( SolrFields.SOLR_LINKS, link );
 			}
 			// Store the data from the links:
-			Iterator<String> iterator = null;
 			if( this.extractLinkHosts ) {
-				iterator = hosts.keySet().iterator();
-				while( iterator.hasNext() ) {
-					solr.addField( SolrFields.SOLR_LINKS_HOSTS, iterator.next() );
+                for (String host: hosts) {
+					solr.addField( SolrFields.SOLR_LINKS_HOSTS, host );
 				}
 			}
 			if( this.extractLinkDomains ) {
-				iterator = domains.keySet().iterator();
-				while( iterator.hasNext() ) {
-					solr.addField( SolrFields.SOLR_LINKS_DOMAINS, iterator.next() );
+                for (String domain: domains) {
+					solr.addField( SolrFields.SOLR_LINKS_DOMAINS, domain );
 				}
 			}
-			iterator = suffixes.keySet().iterator();
-			while( iterator.hasNext() ) {
-				solr.addField( SolrFields.SOLR_LINKS_PUBLIC_SUFFIXES, iterator.next() );
+            for (String suffix: suffixes) {
+				solr.addField( SolrFields.SOLR_LINKS_PUBLIC_SUFFIXES, suffix );
 			}
 		}
 		// Process element usage:
@@ -144,7 +142,7 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 		for( String lurl : metadata.getValues( Metadata.LICENSE_URL ) ) {
 			solr.addField( SolrFields.LICENSE_URL, lurl );
 		}
-        Instrument.timeRel("HTMLAnalyzer.analyze", start);
+        Instrument.timeRel("HTMLAnalyzer.analyze#total", start);
     }
 	
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/ImageAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/ImageAnalyser.java
@@ -83,7 +83,6 @@ public class ImageAnalyser extends AbstractPayloadAnalyser {
 	@Override
 	public void analyse(ArchiveRecordHeader header, InputStream tikainput,
 			SolrRecord solr) {
-        final long start = System.nanoTime();
 		// Set up metadata object to pass to parsers:
 		Metadata metadata = new Metadata();
 		// Skip large images:
@@ -99,6 +98,7 @@ public class ImageAnalyser extends AbstractPayloadAnalyser {
 
 			// Attempt to extract faces etc.:
 			if (this.extractFaces || this.extractDominantColours) {
+                final long deepStart = System.nanoTime();
 				ParseRunner parser = new ParseRunner(fdp, tikainput, metadata,
 						solr);
 				Thread thread = new Thread(parser, Long.toString(System
@@ -135,10 +135,11 @@ public class ImageAnalyser extends AbstractPayloadAnalyser {
 					solr.addField(SolrFields.IMAGE_DOMINANT_COLOUR,
 							metadata.get(FaceDetectionParser.DOM_COL));
 				}
+                Instrument.timeRel("WARCPayloadAnalyzers.analyze#total",
+                                   "ImageAnalyzer.analyze#facesanddominant", deepStart);
 			}
 
 		}
-        Instrument.timeRel("ImageAnalyzer.analyze", start);
 	}
 
 	public long getSampleCount() {

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/ImageAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/ImageAnalyser.java
@@ -37,6 +37,7 @@ import uk.bl.wa.solr.SolrRecord;
 import uk.bl.wa.tika.parser.imagefeatures.FaceDetectionParser;
 
 import com.typesafe.config.Config;
+import uk.bl.wa.util.Instrument;
 
 /**
  * @author anj
@@ -82,6 +83,7 @@ public class ImageAnalyser extends AbstractPayloadAnalyser {
 	@Override
 	public void analyse(ArchiveRecordHeader header, InputStream tikainput,
 			SolrRecord solr) {
+        final long start = System.nanoTime();
 		// Set up metadata object to pass to parsers:
 		Metadata metadata = new Metadata();
 		// Skip large images:
@@ -136,6 +138,7 @@ public class ImageAnalyser extends AbstractPayloadAnalyser {
 			}
 
 		}
+        Instrument.timeRel("ImageAnalyzer.analyze", start);
 	}
 
 	public long getSampleCount() {

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/PDFAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/PDFAnalyser.java
@@ -38,6 +38,7 @@ import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
 
 import com.typesafe.config.Config;
+import uk.bl.wa.util.Instrument;
 
 /**
  * @author anj
@@ -58,6 +59,7 @@ public class PDFAnalyser extends AbstractPayloadAnalyser {
 	@Override
 	public void analyse(ArchiveRecordHeader header, InputStream tikainput,
 			SolrRecord solr) {
+        final long start = System.nanoTime();
 		Metadata metadata = new Metadata();
 		metadata.set(Metadata.RESOURCE_NAME_KEY, header.getUrl());
 		ParseRunner parser = new ParseRunner(app, tikainput, metadata, solr);
@@ -96,6 +98,7 @@ public class PDFAnalyser extends AbstractPayloadAnalyser {
 				solr.addField(SolrFields.PDFA_ERRORS, error);
 			}
 		}
+        Instrument.timeRel("PDFAnalyzer.analyze", start);
 	}
 
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/PDFAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/PDFAnalyser.java
@@ -98,7 +98,8 @@ public class PDFAnalyser extends AbstractPayloadAnalyser {
 				solr.addField(SolrFields.PDFA_ERRORS, error);
 			}
 		}
-        Instrument.timeRel("PDFAnalyzer.analyze", start);
+        Instrument.timeRel("WARCPayloadAnalyzers.analyze#total",
+                           "PDFAnalyzer.analyze", start);
 	}
 
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/WARCPayloadAnalysers.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/WARCPayloadAnalysers.java
@@ -111,7 +111,7 @@ public class WARCPayloadAnalysers {
 	public void analyse(ArchiveRecordHeader header, InputStream tikainput, SolrRecord solr) {
 		log.debug("Analysing "+header.getUrl());
 
-        final long tikaStart = System.nanoTime();
+        final long start = System.nanoTime();
 		// Analyse with tika:
 		try {
 			if( passUriToFormatTools ) {
@@ -122,7 +122,8 @@ public class WARCPayloadAnalysers {
 		} catch( Exception i ) {
 			log.error( i + ": " + i.getMessage() + ";tika; " + header.getUrl() + "@" + header.getOffset() );
 		}
-        Instrument.timeRel("WARCPayloadAnalyzers.analyze#tika", tikaStart);
+        Instrument.timeRel("WARCPayloadAnalyzers.analyze#total",
+                           "WARCPayloadAnalyzers.analyze#tikasolrextract", start);
 
         final long firstBytesStart = System.nanoTime();
 		// Pull out the first few bytes, to hunt for new format by magic:
@@ -145,7 +146,8 @@ public class WARCPayloadAnalysers {
 		} catch( Exception i ) {
 			log.error( i + ": " + i.getMessage() + ";ffb; " + header.getUrl() + "@" + header.getOffset() );
 		}
-        Instrument.timeRel("WARCPayloadAnalyzers.analyze#firstbytes", firstBytesStart);
+        Instrument.timeRel("WARCPayloadAnalyzers.analyze#total",
+                           "WARCPayloadAnalyzers.analyze#firstbytes", firstBytesStart);
 
 		// Also run DROID (restricted range):
 		if( dd != null && runDroid == true ) {
@@ -167,7 +169,8 @@ public class WARCPayloadAnalysers {
 				// Note that DROID complains about some URLs with an IllegalArgumentException.
 				log.error( i + ": " + i.getMessage() + ";dd; " + header.getUrl() + " @" + header.getOffset() );
 			}
-            Instrument.timeRel("WARCPayloadAnalyzers.analyze#droid", droidStart);
+            Instrument.timeRel("WARCPayloadAnalyzers.analyze#total",
+                               "WARCPayloadAnalyzers.analyze#droid", droidStart);
 		}
 		
 		try {
@@ -195,6 +198,8 @@ public class WARCPayloadAnalysers {
 		} catch( Exception i ) {
 			log.error( i + ": " + i.getMessage() + ";x; " + header.getUrl() + "@" + header.getOffset() );
 		}
-		
+        Instrument.timeRel("WARCIndexer.extract#analyzetikainput",
+                           "WARCPayloadAnalyzers.analyze#total", start);
+
 	}
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/XMLAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/XMLAnalyser.java
@@ -75,7 +75,7 @@ public class XMLAnalyser extends AbstractPayloadAnalyser {
 			}
 			solr.addField( SolrFields.XML_ROOT_NS, metadata.get(XMLRootNamespaceParser.XML_ROOT_NS));
 		}
-        Instrument.timeRel("XMLAnalyzer.analyze", start);
+        Instrument.timeRel("WARCPayloadAnalyzers.analyze#total","XMLAnalyzer.analyze", start);
 	}
 
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/XMLAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/XMLAnalyser.java
@@ -37,6 +37,7 @@ import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
 
 import com.typesafe.config.Config;
+import uk.bl.wa.util.Instrument;
 
 /**
  * @author anj
@@ -58,6 +59,7 @@ public class XMLAnalyser extends AbstractPayloadAnalyser {
 	@Override
 	public void analyse(ArchiveRecordHeader header, InputStream tikainput,
 			SolrRecord solr) {
+        final long start = System.nanoTime();
 		Metadata metadata = new Metadata();
 		// Also attempt to grab the XML Root NS:
 		if( this.extractXMLRootNamespace ) {
@@ -73,6 +75,7 @@ public class XMLAnalyser extends AbstractPayloadAnalyser {
 			}
 			solr.addField( SolrFields.XML_ROOT_NS, metadata.get(XMLRootNamespaceParser.XML_ROOT_NS));
 		}
+        Instrument.timeRel("XMLAnalyzer.analyze", start);
 	}
 
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/text/FuzzyHashAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/text/FuzzyHashAnalyser.java
@@ -35,6 +35,7 @@ import eu.scape_project.bitwiser.utils.FuzzyHash;
 import eu.scape_project.bitwiser.utils.SSDeep;
 import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
+import uk.bl.wa.util.Instrument;
 
 /**
  * @author anj
@@ -53,6 +54,7 @@ public class FuzzyHashAnalyser extends AbstractTextAnalyser {
 	 */
 	@Override
 	public void analyse(String text, SolrRecord solr) {
+        final long start = System.nanoTime();
 		// Canonicalize the text - strip newlines etc.
 		Pattern whitespace = Pattern.compile( "\\s+" );
 		Matcher matcher = whitespace.matcher( text );
@@ -73,7 +75,7 @@ public class FuzzyHashAnalyser extends AbstractTextAnalyser {
 		} catch (UnsupportedEncodingException e) {
 			e.printStackTrace();
 		}
-		
+        Instrument.timeRel("TextAnalyzers#total", "FuzzyHashAnalyzer", start);
 	}
 
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/text/LanguageAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/text/LanguageAnalyser.java
@@ -33,6 +33,7 @@ import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
 
 import com.typesafe.config.Config;
+import uk.bl.wa.util.Instrument;
 
 /**
  * @author anj
@@ -56,9 +57,12 @@ public class LanguageAnalyser extends AbstractTextAnalyser {
 	 */
 	@Override
 	public void analyse(String text, SolrRecord solr) {
+        final long start = System.nanoTime();
 		String li = ld.detectLanguage( text );
-		if( li != null )
+		if( li != null ) {
 			solr.addField( SolrFields.CONTENT_LANGUAGE, li );
+        }
+        Instrument.timeRel("TextAnalyzers#total", "LanguageAnalyzer#total", start);
 	}
 
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/text/PostcodeAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/text/PostcodeAnalyser.java
@@ -35,6 +35,7 @@ import com.typesafe.config.Config;
 import uk.bl.wa.extract.PostcodeGeomapper;
 import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
+import uk.bl.wa.util.Instrument;
 
 /**
  * @author anj
@@ -58,6 +59,7 @@ public class PostcodeAnalyser extends AbstractTextAnalyser {
 	 */
 	@Override
 	public void analyse(String text, SolrRecord solr) {
+        final long start = System.nanoTime();
 		// Postcode Extractor (based on text extracted by Tika)
 		Matcher pcm = postcodePattern.matcher( text );
 		Set<String> pcs = new HashSet<String>();
@@ -71,6 +73,7 @@ public class PostcodeAnalyser extends AbstractTextAnalyser {
 			if( location != null )
 				solr.addField( SolrFields.LOCATIONS, location );
 		}
+        Instrument.timeRel("TextAnalyzers#total", "PostcodeAnalyzer", start);
 	}
 
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/text/TextAnalysers.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/text/TextAnalysers.java
@@ -32,6 +32,7 @@ import com.typesafe.config.Config;
 
 import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
+import uk.bl.wa.util.Instrument;
 
 /**
  * @author anj
@@ -65,6 +66,7 @@ public class TextAnalysers {
 	 * @param solr
 	 */
 	public void analyse( SolrRecord solr ) {
+        final long start = System.nanoTime();
 		// Pull out the text:
 		if( solr.getField( SolrFields.SOLR_EXTRACTED_TEXT ) != null ) {
 			String text = ( String ) solr.getField( SolrFields.SOLR_EXTRACTED_TEXT ).getFirstValue();
@@ -75,6 +77,7 @@ public class TextAnalysers {
 				}
 			}
 		}
+        Instrument.timeRel("WARCIndexer.extract#total", "TextAnalyzers#total", start);
 	}
 	
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/extract/LanguageDetector.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/extract/LanguageDetector.java
@@ -40,6 +40,7 @@ import org.apache.tika.language.LanguageIdentifier;
 import com.cybozu.labs.langdetect.Detector;
 import com.cybozu.labs.langdetect.DetectorFactory;
 import com.cybozu.labs.langdetect.LangDetectException;
+import uk.bl.wa.util.Instrument;
 
 /**
  * @author Andrew Jackson <Andrew.Jackson@bl.uk>
@@ -75,7 +76,7 @@ public class LanguageDetector {
 		try {
 			DetectorFactory.loadProfile(json_profiles);
 		} catch( LangDetectException e) {
-			log.error("Error occured when loading language profiles:"+e+" Language detection will likely fail. ");
+			log.error("Error occurred when loading language profiles:"+e+" Language detection will likely fail. ");
 		}
 		}
 	}
@@ -98,15 +99,25 @@ public class LanguageDetector {
 	}
 	
 	public String detectLanguage( String text ) {
-		// Attept to use Tika module first (should be good for long texts)
-		LanguageIdentifier li = new LanguageIdentifier(text);
-		// Only return that result if it's credible:
-		if( li.isReasonablyCertain() ) return li.getLanguage();
-		// Otherwise, fall back to the langdetect approach (should be better for short texts)
-		// (Having found that (very) short texts are not likely to be classified sensibly.)
-		if( text.length() > 200 )
-			return this.getLangdetectLanguage(text);
-		return null;
+        final long start = System.nanoTime();
+        try {
+            // Attept to use Tika module first (should be good for long texts)
+            LanguageIdentifier li = new LanguageIdentifier(text);
+            // Only return that result if it's credible:
+            if( li.isReasonablyCertain() ) return li.getLanguage();
+        } finally {
+            Instrument.timeRel("LanguageAnalyzer#total", "LanguageDetector.detectLanguage#li", start);
+        }
+        final long startLD = System.nanoTime();
+        try {
+            // Otherwise, fall back to the langdetect approach (should be better for short texts)
+            // (Having found that (very) short texts are not likely to be classified sensibly.)
+            if( text.length() > 200 )
+                return this.getLangdetectLanguage(text);
+            return null;
+        } finally {
+            Instrument.timeRel("LanguageAnalyzer#total", "LanguageDetector.detectLanguage#ld", start);
+        }
 	}
 	/**
 	 * @param args

--- a/warc-indexer/src/main/java/uk/bl/wa/extract/LanguageDetector.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/extract/LanguageDetector.java
@@ -116,7 +116,7 @@ public class LanguageDetector {
                 return this.getLangdetectLanguage(text);
             return null;
         } finally {
-            Instrument.timeRel("LanguageAnalyzer#total", "LanguageDetector.detectLanguage#ld", start);
+            Instrument.timeRel("LanguageAnalyzer#total", "LanguageDetector.detectLanguage#ld", startLD);
         }
 	}
 	/**

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -328,6 +328,8 @@ public class WARCIndexer {
 			solr.setField( SolrFields.DOMAIN, LinkExtractor.extractPrivateSuffixFromHost( host ) );
 			solr.setField( SolrFields.PUBLIC_SUFFIX, LinkExtractor.extractPublicSuffixFromHost( host ) );
 
+            Instrument.timeRel("WARCIndexer.extract#archeaders", start);
+
 			InputStream tikainput = null;
 
 			// Only parse HTTP headers for HTTP URIs
@@ -383,9 +385,11 @@ public class WARCIndexer {
 			// -----------------------------------------------------
 			
 			// Create an appropriately cached version of the payload, to allow analysis.
+            final long hashStreamStart = System.nanoTime();
 			HashedCachedInputStream hcis = new HashedCachedInputStream(header, tikainput, content_length );
 			tikainput = hcis.getInputStream();
 			String hash = hcis.getHash();
+            Instrument.timeRel("WARCIndexer.extract#hashstreamwrap", start);
 
 			// Prepare crawl date information:
 			String waybackDate = ( header.getDate().replaceAll( "[^0-9]", "" ) );
@@ -484,13 +488,16 @@ public class WARCIndexer {
 			// -----------------------------------------------------
 			// Payload duplication has been checked, ready to parse:
 			// -----------------------------------------------------
-			
+
+            final long analyzeStart = System.nanoTime();
 			// Mark the start of the payload.
 			tikainput.mark( ( int ) content_length );
 			
 			// Pass on to other extractors as required, resetting the stream before each:
 			this.wpa.analyse(header, tikainput, solr);
-			
+            Instrument.timeRel("WARCIndexer.extract#analyzetikainput", start);
+
+
 			// Clear up the caching of the payload:
 			hcis.cleanup();
 
@@ -501,8 +508,10 @@ public class WARCIndexer {
 			// Payload analysis complete, now performing text analysis:
 			// -----------------------------------------------------
 			
+            final long textStart = System.nanoTime();
 			this.txa.analyse(solr);
-			
+            Instrument.timeRel("WARCIndexer.extract#analyzetext", start);
+
 			// Remove the Text Field if required
 			if( !isTextIncluded ) {
 				solr.removeField( SolrFields.SOLR_EXTRACTED_TEXT );

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -82,6 +82,7 @@ import uk.bl.wa.util.HashedCachedInputStream;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
+import uk.bl.wa.util.Instrument;
 
 /**
  * 
@@ -251,6 +252,7 @@ public class WARCIndexer {
 	 * @throws IOException
 	 */
 	public SolrRecord extract( String archiveName, ArchiveRecord record, boolean isTextIncluded ) throws IOException {
+        final long start = System.nanoTime();
 		ArchiveRecordHeader header = record.getHeader();
 		SolrRecord solr = new SolrRecord(archiveName, header);
 		
@@ -519,7 +521,8 @@ public class WARCIndexer {
 				}
 			}
 		}
-		return solr;
+        Instrument.timeRel("WARCIndexer.extract#full", start);
+        return solr;
 	}
 
 	/**

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -328,7 +328,8 @@ public class WARCIndexer {
 			solr.setField( SolrFields.DOMAIN, LinkExtractor.extractPrivateSuffixFromHost( host ) );
 			solr.setField( SolrFields.PUBLIC_SUFFIX, LinkExtractor.extractPublicSuffixFromHost( host ) );
 
-            Instrument.timeRel("WARCIndexer.extract#archeaders", start);
+            Instrument.timeRel("WARCIndexer.extract#total",
+                               "WARCIndexer.extract#archeaders", start);
 
 			InputStream tikainput = null;
 
@@ -389,7 +390,8 @@ public class WARCIndexer {
 			HashedCachedInputStream hcis = new HashedCachedInputStream(header, tikainput, content_length );
 			tikainput = hcis.getInputStream();
 			String hash = hcis.getHash();
-            Instrument.timeRel("WARCIndexer.extract#hashstreamwrap", start);
+            Instrument.timeRel("WARCIndexer.extract#total",
+                               "WARCIndexer.extract#hashstreamwrap", start);
 
 			// Prepare crawl date information:
 			String waybackDate = ( header.getDate().replaceAll( "[^0-9]", "" ) );
@@ -495,7 +497,7 @@ public class WARCIndexer {
 			
 			// Pass on to other extractors as required, resetting the stream before each:
 			this.wpa.analyse(header, tikainput, solr);
-            Instrument.timeRel("WARCIndexer.extract#analyzetikainput", start);
+            Instrument.timeRel("WARCIndexer.extract#total", "WARCIndexer.extract#analyzetikainput", analyzeStart);
 
 
 			// Clear up the caching of the payload:
@@ -508,9 +510,7 @@ public class WARCIndexer {
 			// Payload analysis complete, now performing text analysis:
 			// -----------------------------------------------------
 			
-            final long textStart = System.nanoTime();
 			this.txa.analyse(solr);
-            Instrument.timeRel("WARCIndexer.extract#analyzetext", start);
 
 			// Remove the Text Field if required
 			if( !isTextIncluded ) {
@@ -530,7 +530,8 @@ public class WARCIndexer {
 				}
 			}
 		}
-        Instrument.timeRel("WARCIndexer.extract#full", start);
+        Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#solrdocCreation",
+                           "WARCIndexer.extract#total", start);
         return solr;
 	}
 

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -278,6 +278,7 @@ public class WARCIndexerCommand {
 			
 			// Iterate though each record in the WARC file
 			while( ir.hasNext() ) {
+                final long recordStart = System.nanoTime();
 				ArchiveRecord rec = ir.next();
 				SolrRecord doc = new SolrRecord(inFile.getName(),
 						rec.getHeader());
@@ -296,6 +297,7 @@ public class WARCIndexerCommand {
 				}
 
 				if( doc != null ) {
+                    Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#solrdocCreation", recordStart);
 					File fileOutput = new File(outputWarcDir + "//" + "FILE_" + recordCount + ".xml");
 					
 					if( !slashPages || ( doc.getFieldValue( SolrFields.SOLR_URL_TYPE ) != null &&
@@ -320,6 +322,7 @@ public class WARCIndexerCommand {
 				}			
 			}
 			curInputFile++;
+            Instrument.log(false);
 		}
 
         if (!disableCommit) {
@@ -330,6 +333,7 @@ public class WARCIndexerCommand {
 		long endTime = System.currentTimeMillis();
 
 		System.out.println("WARC Indexer Finished in "+((endTime-startTime)/1000.0)+" seconds.");
+        Instrument.log(true);
 	}
 	
 	private static void commit( SolrWebServer solrWeb) {

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -364,8 +364,8 @@ public class WARCIndexerCommand {
 	private static void checkSubmission( SolrWebServer solr, List<SolrInputDocument> docs, int limit ) throws SolrServerException, IOException {
 		if( docs.size() > 0 && docs.size() >= limit ) {
 			solr.add( docs );
+            docs.clear();
 		}
-		docs.clear();
 	}
 	
 	

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -199,8 +199,10 @@ public class WARCIndexerCommand {
 		
 		} catch (org.apache.commons.cli.ParseException e) {
 			log.error("Parse exception when processing command line arguments: "+e);
-		}
-        Instrument.timeRel("WARCIndexerCommand.all", allStart);
+		} finally {
+            Instrument.timeRel("WARCIndexerCommand.main#total", allStart);
+            Instrument.log(true);
+        }
 	}
 	
 	/**
@@ -219,6 +221,7 @@ public class WARCIndexerCommand {
 			TransformerFactoryConfigurationError, TransformerException,
 			IOException {
 		long startTime = System.currentTimeMillis();
+        final long start = System.nanoTime();
 
 		// If the Solr URL is set initiate a connections
 		Config conf = ConfigFactory.load();
@@ -256,6 +259,8 @@ public class WARCIndexerCommand {
 		int totInputFile = args.length;
 		int curInputFile = 1;
 					
+        Instrument.timeRel("WARCIndexerCommand.main#total",
+                           "WARCIndexerCommand.parseWarcFiles#startup", start);
 		// Loop through each Warc files
 		for( String inputFile : args ) {
             if (!disableCommit) {
@@ -297,7 +302,8 @@ public class WARCIndexerCommand {
 				}
 
 				if( doc != null ) {
-                    Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#solrdocCreation", recordStart);
+                    Instrument.timeRel("WARCIndexerCommand.main#total",
+                                       "WARCIndexerCommand.parseWarcFiles#solrdocCreation", recordStart);
 					File fileOutput = new File(outputWarcDir + "//" + "FILE_" + recordCount + ".xml");
 					
 					if( !slashPages || ( doc.getFieldValue( SolrFields.SOLR_URL_TYPE ) != null &&
@@ -332,8 +338,7 @@ public class WARCIndexerCommand {
 
 		long endTime = System.currentTimeMillis();
 
-		System.out.println("WARC Indexer Finished in "+((endTime-startTime)/1000.0)+" seconds.");
-        Instrument.log(true);
+		System.out.println("WARC Indexer Finished in " + ((endTime - startTime) / 1000.0) + " seconds.");
 	}
 	
 	private static void commit( SolrWebServer solrWeb) {
@@ -342,7 +347,7 @@ public class WARCIndexerCommand {
 			try {
                 final long start = System.nanoTime();
 				solrWeb.commit();
-                Instrument.timeRel("WARCIndexerCommand.commit#success", start);
+                Instrument.timeRel("WARCIndexerCommand.main#total", "WARCIndexerCommand.commit#success", start);
 			} catch( SolrServerException s ) {
 				log.warn( "SolrServerException when committing.", s );
 			} catch( IOException i ) {

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecord.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecord.java
@@ -42,6 +42,7 @@ import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
 import org.archive.io.ArchiveRecordHeader;
+import uk.bl.wa.util.Instrument;
 
 /**
  * @author Andrew Jackson <Andrew.Jackson@bl.uk>
@@ -77,12 +78,15 @@ public class SolrRecord implements Serializable {
 	 * @return
 	 */
 	private String removeControlCharacters( String value ) {
+        final long start = System.nanoTime();
 		try {
 			return sanitiseUTF8(value.trim().replaceAll("\\p{Space}", " ")
 					.replaceAll("\\p{Cntrl}", ""));
 		} catch (CharacterCodingException e) {
 			return "";
-		}
+		} finally {
+            Instrument.timeRel("SolrRecord.removeControlCharacters", start);
+        }
 	}
 	
 	/**
@@ -97,18 +101,23 @@ public class SolrRecord implements Serializable {
 	 * @throws CharacterCodingException
 	 */
 	private String sanitiseUTF8(String value) throws CharacterCodingException {
-		// Take a string, map it to bytes as UTF-8:
-		CharsetEncoder encoder = Charset.forName("UTF-8").newEncoder();
-		encoder.onMalformedInput(CodingErrorAction.REPLACE);
-		encoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
-		ByteBuffer bytes = encoder.encode(CharBuffer.wrap(value));
-		// Now decode back again:
-		CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder();
-		decoder.onMalformedInput(CodingErrorAction.REPLACE);
-		decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
-		CharBuffer parsed = decoder.decode(bytes);
-		// And return the string:
+        final long start = System.nanoTime();
+        try  {
+            // Take a string, map it to bytes as UTF-8:
+            CharsetEncoder encoder = Charset.forName("UTF-8").newEncoder();
+            encoder.onMalformedInput(CodingErrorAction.REPLACE);
+            encoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
+            ByteBuffer bytes = encoder.encode(CharBuffer.wrap(value));
+            // Now decode back again:
+            CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder();
+            decoder.onMalformedInput(CodingErrorAction.REPLACE);
+            decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
+            CharBuffer parsed = decoder.decode(bytes);
+            // And return the string:
 		return parsed.toString();
+        } finally {
+            Instrument.timeRel("SolrRecord.sanitiseUTF8", start);
+        }
 	}
 
 

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecord.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecord.java
@@ -85,7 +85,7 @@ public class SolrRecord implements Serializable {
 		} catch (CharacterCodingException e) {
 			return "";
 		} finally {
-            Instrument.timeRel("SolrRecord.removeControlCharacters", start);
+            Instrument.timeRel("SolrRecord.removeControlCharacters#total", start);
         }
 	}
 	
@@ -116,7 +116,7 @@ public class SolrRecord implements Serializable {
             // And return the string:
 		return parsed.toString();
         } finally {
-            Instrument.timeRel("SolrRecord.sanitiseUTF8", start);
+            Instrument.timeRel("SolrRecord.removeControlCharacters#total", "SolrRecord.sanitiseUTF8", start);
         }
 	}
 

--- a/warc-indexer/src/main/java/uk/bl/wa/util/Instrument.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Instrument.java
@@ -1,0 +1,130 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package uk.bl.wa.util;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Helper class for lightweight performance-measuring instrumentation of the code base.
+ * By nature the class is shared by the whole JVM.
+ * </p><p>
+ * Usage: Call {@code Instrument.time(customid, nanotime)} at relevant places in the code.
+ */
+public class Instrument {
+    private static Log log = LogFactory.getLog(Instrument.class);
+
+    private static final Map<String, Stats> trackers = new HashMap<String, Stats>();
+
+    /**
+     * Increment the total time for the tracker with the given ID.
+     * The delta is calculated with {@code System.nanotime() - nanoStart}.
+     * @param id        id for a tracker. If it does not exist, it will be created.
+     * @param nanoStart the start time of the measurement.
+     */
+    public static void timeRel(String id, long nanoStart) {
+        time(id, System.nanoTime() - nanoStart);
+    }
+
+    /**
+     * Increment the total time for the tracker with the given ID.
+     * Synchronized to handle creation of new Stats.
+     * @param id           id for a tracker. If it does not exist, it will be created.
+     * @param nanoAbsolute the amount of nanoseconds to add.
+     */
+    public static synchronized void time(String id, long nanoAbsolute) {
+        Stats stats = trackers.get(id);
+        if (stats == null) {
+            stats = new Stats(id);
+            trackers.put(id, stats);
+        }
+        stats.time(nanoAbsolute);
+    }
+
+    public static class Stats {
+        public final String id;
+        public final AtomicLong time = new AtomicLong(0);
+        public final AtomicLong count = new AtomicLong(0);
+        private static final double MD = 1000000d;
+
+        public Stats(String id) {
+            this.id = id;
+        }
+
+        public void time(long nanoAbsolute) {
+            time.addAndGet(nanoAbsolute);
+            count.incrementAndGet();
+        }
+
+        public String toString() {
+            return String.format("%s(num=%d, time=%.2fms, avg=%.2fnum/ms %.2fms/num",
+                                 id, count.get(), time.get()/MD,
+                                 time.get() == 0 ? 0 : count.get() / (time.get() / MD),
+                                 count.get() == 0 ? 0 : time.get() / MD / time.get());
+        }
+    }
+
+    /**
+     * Logs collected statistics.
+     * @param major if true, the report is logged at INFO level. If false, DEBUG.
+     */
+    public static void log(boolean major) {
+        if (major) {
+            log.info(getStats());
+        } else {
+            log.debug(getStats());
+        }
+    }
+
+    private static String getStats() {
+        StringBuilder sb = new StringBuilder();
+        for (Stats stats: trackers.values()) {
+            if (sb.length() != 0) {
+                sb.append(", ");
+            }
+            sb.append(stats);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Adds a hook to the JVM listening for shutdown and logging when it happens.
+     */
+    public static void addLoggingShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(new CustomShutdownHook("Shutdown stats logging"));
+    }
+    private static class CustomShutdownHook extends Thread {
+        private CustomShutdownHook(String name) {
+            super(name);
+        }
+
+        @Override
+        public void run(){
+            try {
+                log.info("JVM shutdown detected, dumping collected performance statistics");
+                Instrument.log(true);
+            } catch (NullPointerException ne) {
+                System.err.println("Unable to properly log performance statistics as the logging system has shut down");
+                System.err.println(Instrument.getStats());
+            }
+
+        }
+    }
+
+}

--- a/warc-indexer/src/main/java/uk/bl/wa/util/Instrument.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Instrument.java
@@ -1,17 +1,3 @@
-/*
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- */
 package uk.bl.wa.util;
 
 /*

--- a/warc-indexer/src/main/java/uk/bl/wa/util/Instrument.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Instrument.java
@@ -14,6 +14,28 @@
  */
 package uk.bl.wa.util;
 
+/*
+ * #%L
+ * warc-indexer
+ * %%
+ * Copyright (C) 2013 - 2015 The UK Web Archive
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.logging.Log;
 

--- a/warc-indexer/src/main/java/uk/bl/wa/util/Instrument.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Instrument.java
@@ -95,10 +95,10 @@ public class Instrument {
         }
 
         public String toString() {
-            return String.format("%s(num=%d, time=%.2fms, avg=%.2fnum/ms %.2fms/num",
+            return String.format("%s(#=%d, time=%.2fms, avg=%.2f#/ms %.2fms/#)",
                                  id, count.get(), time.get()/MD,
                                  time.get() == 0 ? 0 : count.get() / (time.get() / MD),
-                                 count.get() == 0 ? 0 : time.get() / MD / time.get());
+                                 count.get() == 0 ? 0 : time.get() / MD / count.get());
         }
     }
 

--- a/warc-indexer/src/main/java/uk/bl/wa/util/Instrument.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Instrument.java
@@ -38,16 +38,23 @@ package uk.bl.wa.util;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.logging.Log;
+import org.apache.zookeeper.data.Stat;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Helper class for lightweight performance-measuring instrumentation of the code base.
- * By nature the class is shared by the whole JVM.
+ * By nature the class is shared by the whole JVM. As a consequence it it Thread safe.
  * </p><p>
  * Usage: Call {@code Instrument.time(customid, nanotime)} at relevant places in the code.
+ * </p><p>
+ * Note: The overhead of calling methods on this class is kept to a minimum.
+ * The only methods with non-trivial overheads are {@link #log(boolean)} and {@link #getStats()}.
+ * @author Toke Eskildsen <te@statsbiblioteket.dk>
  */
 public class Instrument {
     private static Log log = LogFactory.getLog(Instrument.class);
@@ -61,7 +68,18 @@ public class Instrument {
      * @param nanoStart the start time of the measurement.
      */
     public static void timeRel(String id, long nanoStart) {
-        time(id, System.nanoTime() - nanoStart);
+        time(null, id, System.nanoTime() - nanoStart);
+    }
+
+    /**
+     * Increment the total time for the tracker with the given ID.
+     * The delta is calculated with {@code System.nanotime() - nanoStart}.
+     * @param parent       provides hierarchical output. If the parent does not exist, it will be created.
+     * @param id        id for a tracker. If it does not exist, it will be created.
+     * @param nanoStart the start time of the measurement.
+     */
+    public static void timeRel(String parent, String id, long nanoStart) {
+        time(parent, id, System.nanoTime() - nanoStart);
     }
 
     /**
@@ -71,18 +89,42 @@ public class Instrument {
      * @param nanoAbsolute the amount of nanoseconds to add.
      */
     public static synchronized void time(String id, long nanoAbsolute) {
+        time(null, id, nanoAbsolute);
+    }
+
+    /**
+     * Increment the total time for the tracker with the given ID.
+     * Synchronized to handle creation of new Stats.
+     * @param parent       provides hierarchical output. If the parent does not exist, it will be created.
+     * @param id           id for a tracker. If it does not exist, it will be created.
+     * @param nanoAbsolute the amount of nanoseconds to add.
+     */
+    public static synchronized void time(String parent, String id, long nanoAbsolute) {
         Stats stats = trackers.get(id);
         if (stats == null) {
             stats = new Stats(id);
             trackers.put(id, stats);
         }
         stats.time(nanoAbsolute);
+
+        // Check parent connection
+        if (parent == null) {
+            return;
+        }
+
+        Stats pStats = trackers.get(parent);
+        if (pStats == null) {
+            pStats = new Stats(parent);
+            trackers.put(parent, pStats);
+        }
+        pStats.addChild(stats);
     }
 
     public static class Stats {
         public final String id;
         public final AtomicLong time = new AtomicLong(0);
         public final AtomicLong count = new AtomicLong(0);
+        public final Set<Stats> children = new HashSet<Stats>();
         private static final double MD = 1000000d;
 
         public Stats(String id) {
@@ -100,6 +142,19 @@ public class Instrument {
                                  time.get() == 0 ? 0 : count.get() / (time.get() / MD),
                                  count.get() == 0 ? 0 : time.get() / MD / count.get());
         }
+
+        public void addChild(Stats child) {
+            children.add(child);
+        }
+
+        @Override
+        public int hashCode() {
+            return id.hashCode();
+        }
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof Stats && id.equals(((Stats) obj).id);
+        }
     }
 
     /**
@@ -108,21 +163,35 @@ public class Instrument {
      */
     public static void log(boolean major) {
         if (major) {
-            log.info(getStats());
+            log.info("Performance statistics\n" + getStats());
         } else {
-            log.debug(getStats());
+            log.debug("Performance statistics\n" + getStats());
         }
     }
 
-    private static String getStats() {
-        StringBuilder sb = new StringBuilder();
+    public static String getStats() {
+        Set<Stats> topLevel = new HashSet<Stats>(trackers.values());
         for (Stats stats: trackers.values()) {
-            if (sb.length() != 0) {
-                sb.append(", ");
+            for (Stats child: stats.children) {
+                topLevel.remove(child);
             }
-            sb.append(stats);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (Stats stats: topLevel) {
+            getStatsRecursive(stats, sb, "");
         }
         return sb.toString();
+    }
+
+    private static void getStatsRecursive(Stats stats, StringBuilder sb, String indent) {
+        if (sb.length() != 0) {
+            sb.append("\n");
+        }
+        sb.append(indent).append(stats);
+        for (Stats child: stats.children) {
+            getStatsRecursive(child, sb, indent + "  ");
+        }
     }
 
     /**

--- a/warc-indexer/src/main/resources/reference.conf
+++ b/warc-indexer/src/main/resources/reference.conf
@@ -135,7 +135,7 @@
             # Is this a dummy-run? (i.e. should we NOT post to SOLR?)
             "dummy_run" : false,
             # Disable explicit commit
-            "disablecommit" : true,
+            "disablecommit" : false,
         },
         
         # HTTP Proxy to use when talking to Solr (if any):

--- a/warc-indexer/src/main/resources/reference.conf
+++ b/warc-indexer/src/main/resources/reference.conf
@@ -134,6 +134,8 @@
             "num_threads" : 1,
             # Is this a dummy-run? (i.e. should we NOT post to SOLR?)
             "dummy_run" : false,
+            # Disable explicit commit
+            "disablecommit" : true,
         },
         
         # HTTP Proxy to use when talking to Solr (if any):

--- a/warc-indexer/src/test/java/uk/bl/wa/solr/TikaExtractorTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/solr/TikaExtractorTest.java
@@ -3,6 +3,28 @@
  */
 package uk.bl.wa.solr;
 
+/*
+ * #%L
+ * warc-indexer
+ * %%
+ * Copyright (C) 2013 - 2015 The UK Web Archive
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/warc-indexer/src/test/java/uk/bl/wa/solr/TikaExtractorTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/solr/TikaExtractorTest.java
@@ -5,7 +5,6 @@ package uk.bl.wa.solr;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.net.URL;
@@ -43,7 +42,6 @@ public class TikaExtractorTest {
 				text.contains("Mona Lisa"));
 		assertFalse("Text should NOT contain this string!",
 				text.contains("encyclopediaMona"));
-		fail("Not yet implemented");
 	}
 
 }

--- a/warc-indexer/src/test/java/uk/bl/wa/util/InstrumentTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/InstrumentTest.java
@@ -1,17 +1,3 @@
-/*
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- */
 package uk.bl.wa.util;
 
 /*

--- a/warc-indexer/src/test/java/uk/bl/wa/util/InstrumentTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/InstrumentTest.java
@@ -1,0 +1,55 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package uk.bl.wa.util;
+
+/*
+ * #%L
+ * warc-indexer
+ * %%
+ * Copyright (C) 2013 - 2015 The UK Web Archive
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import junit.framework.TestCase;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
+
+public class InstrumentTest extends TestCase {
+    private static Log log = LogFactory.getLog(InstrumentTest.class);
+
+    // Not a real test as it requires visual inspection
+    public void testHierarchical() {
+        Instrument.time("top", 123456);
+        Instrument.time("top", "mid1", 123457);
+        Instrument.time("top", "mid2", 123459);
+        Instrument.time("mid1", "bottom", 123460);
+        assertTrue("There should be a double indent in\n" + Instrument.getStats(),                   Instrument.getStats().contains("    "));
+    }
+
+}


### PR DESCRIPTION
This pull is primarily about performance instrumentation: The class Instrument was added for lightweight tracking of where the time is spend (sample output below). The final report is currently only triggered by the `WARCIndexerCommand` with `Instrument.log(true)`.

Eye opener: Detecting language on our (admittedly tiny) sample took 1/5th of the total time.

```
WARC Indexer Finished in 180.572 seconds.
2015-02-12 15:43:12 INFO  Instrument:166 - Performance statistics
SolrRecord.removeControlCharacters#total(#=253778, time=3003.60ms, avg=84.49#/ms 0.01ms/#)
  SolrRecord.sanitiseUTF8(#=253778, time=961.46ms, avg=263.95#/ms 0.00ms/#)
WARCIndexerCommand.main#total(#=1, time=180577.93ms, avg=0.00#/ms 180577.93ms/#)
  WARCIndexerCommand.parseWarcFiles#startup(#=1, time=4681.03ms, avg=0.00#/ms 4681.03ms/#)
  WARCIndexerCommand.parseWarcFiles#solrdocCreation(#=2973, time=172194.94ms, avg=0.02#/ms 57.92ms/#)
    WARCIndexer.extract#total(#=2973, time=171782.62ms, avg=0.02#/ms 57.78ms/#)
      TextAnalyzers#total(#=2973, time=51045.44ms, avg=0.06#/ms 17.17ms/#)
        LanguageAnalyzer#total(#=2762, time=49251.77ms, avg=0.06#/ms 17.83ms/#)
          LanguageDetector.detectLanguage#li(#=2762, time=37463.25ms, avg=0.07#/ms 13.56ms/#)
          LanguageDetector.detectLanguage#ld(#=2762, time=11740.58ms, avg=0.24#/ms 4.25ms/#)
        FuzzyHashAnalyzer(#=2762, time=1411.92ms, avg=1.96#/ms 0.51ms/#)
        PostcodeAnalyzer(#=2762, time=355.36ms, avg=7.77#/ms 0.13ms/#)
      WARCIndexer.extract#hashstreamwrap(#=2973, time=6397.88ms, avg=0.46#/ms 2.15ms/#)
      WARCIndexer.extract#archeaders(#=3377, time=971.33ms, avg=3.48#/ms 0.29ms/#)
      WARCIndexer.extract#analyzetikainput(#=2973, time=113377.54ms, avg=0.03#/ms 38.14ms/#)
        WARCPayloadAnalyzers.analyze#total(#=2973, time=113366.16ms, avg=0.03#/ms 38.13ms/#)
          HTMLAnalyzer.analyze#total(#=2730, time=34759.37ms, avg=0.08#/ms 12.73ms/#)
            HTMLAnalyzer.analyze#parser(#=2730, time=30107.75ms, avg=0.09#/ms 11.03ms/#)
          WARCPayloadAnalyzers.analyze#droid(#=2973, time=16764.40ms, avg=0.18#/ms 5.64ms/#)
          XMLAnalyzer.analyze(#=32, time=34.01ms, avg=0.94#/ms 1.06ms/#)
          WARCPayloadAnalyzers.analyze#tikasolrextract(#=2973, time=54007.04ms, avg=0.06#/ms 18.17ms/#)
          ImageAnalyzer.analyze#facesanddominant(#=13, time=7660.43ms, avg=0.00#/ms 589.26ms/#)
          WARCPayloadAnalyzers.analyze#firstbytes(#=2973, time=125.02ms, avg=23.78#/ms 0.04ms/#)
```