### PR TITLE
Switched HTML links extraction from String join/split on space to String[]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * Reduced schema to required fields only [#49](https://github.com/ukwa/webarchive-discovery/pull/49)
 * The TikaInputStream must be closed to closed to clean up temp files [#50](https://github.com/ukwa/webarchive-discovery/pull/50)
 * Empty terms should not be added [#55](https://github.com/ukwa/webarchive-discovery/pull/55)
+* Switched HTML links extraction from String join/split on space to String[] [#52](https://github.com/ukwa/webarchive-discovery/pull/52)
 
 2.0.0
 -----

--- a/warc-hadoop-indexer/src/main/java/uk/bl/wa/hadoop/outlinks/OutlinkExtractorMapper.java
+++ b/warc-hadoop-indexer/src/main/java/uk/bl/wa/hadoop/outlinks/OutlinkExtractorMapper.java
@@ -51,8 +51,7 @@ public class OutlinkExtractorMapper extends MapReduceBase implements Mapper<Text
 				outputKey = new Text( year + "\t" + resourceHost );
 
 				Metadata metadata = HtmlFeatureParser.extractMetadata( value.getRecord(), resourceUrl );
-				String[] links = metadata.get( HtmlFeatureParser.LINK_LIST ).split( "\\s+" );
-				for( String link : links ) {
+				for( String link : metadata.getValues( HtmlFeatureParser.LINK_LIST ) ) {
 					matcher = pattern.matcher( link );
 					if( matcher.matches() ) {
 						output.collect( outputKey, new Text( matcher.group( 2 ) ) );

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.Property;
 import org.archive.io.ArchiveRecordHeader;
 
 import uk.bl.wa.extract.LinkExtractor;
@@ -95,10 +96,10 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
         Instrument.timeRel("HTMLAnalyzer.analyze#total", "HTMLAnalyzer.analyze#parser", start);
 
 		// Process links:
-		String links_list = metadata.get( HtmlFeatureParser.LINK_LIST );
+		String[] links_list = metadata.getValues( HtmlFeatureParser.LINK_LIST );
 		if( links_list != null ) {
 			String lhost, ldomain, lsuffix;
-			for( String link : links_list.split( " " ) ) {
+			for( String link : links_list ) {
 				lhost = LinkExtractor.extractHost( link );
 				if( !lhost.equals( LinkExtractor.MALFORMED_HOST ) ) {
 					hosts.add(lhost);

--- a/warc-indexer/src/main/java/uk/bl/wa/extract/LinkExtractor.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/extract/LinkExtractor.java
@@ -80,7 +80,7 @@ public class LinkExtractor {
 	 * @throws IOException
 	 */
 	public static Set<String> extractPublicSuffixes( Metadata metadata ) throws IOException {
-		String[] links = metadata.get(HtmlFeatureParser.LINK_LIST).split(" ");
+		String[] links = metadata.getValues(HtmlFeatureParser.LINK_LIST);
 		Set<String> suffixes = new HashSet<String>();
 		for( String link : links ) {
 			String suffix = extractPublicSuffix(link);

--- a/warc-indexer/src/main/java/uk/bl/wa/parsers/HtmlFeatureParser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/parsers/HtmlFeatureParser.java
@@ -69,7 +69,8 @@ public class HtmlFeatureParser extends AbstractParser {
 	private int max_errors;
 
 	public static final String ORIGINAL_PUB_DATE = "OriginalPublicationDate";
-	public static final String LINK_LIST = "LinkList";
+    // Explicit property to get faster link handling as it allows for set with multiple values (same as LINKS?)
+    public static final Property LINK_LIST = Property.internalTextBag("LinkList");
 	public static final Property LINKS = Property.internalTextBag("LINK-LIST");
 	public static final String FIRST_PARAGRAPH = "FirstParagraph";
 	public static final Property DISTINCT_ELEMENTS = Property.internalTextBag("DISTINCT-ELEMENTS");
@@ -145,9 +146,10 @@ public class HtmlFeatureParser extends AbstractParser {
 
 		// Get the links (no image links):
 		Set<String> links = this.extractLinks(doc, false);
-		if( links != null && links.size() > 0 )
-			metadata.set(LINK_LIST, StringUtils.join(links, " "));
-		
+		if( links != null && links.size() > 0 ) {
+			metadata.set(LINK_LIST, links.toArray(new String[links.size()]));
+        }
+
 		// Get the publication date, from BBC pages:
 		for( Element meta : doc.select("meta[name=OriginalPublicationDate]") ) {
 			metadata.set(ORIGINAL_PUB_DATE, meta.attr("content"));

--- a/warc-indexer/src/test/java/uk/bl/wa/analyser/payload/HTMLAnalyserTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/analyser/payload/HTMLAnalyserTest.java
@@ -1,0 +1,89 @@
+package uk.bl.wa.analyser.payload;
+
+/*
+ * #%L
+ * warc-indexer
+ * %%
+ * Copyright (C) 2015 State and University Library, Denmark
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.*;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import org.archive.io.ArchiveRecordHeader;
+import org.archive.io.arc.ARCRecordMetaData;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.Test;
+import uk.bl.wa.parsers.HtmlFeatureParser;
+import uk.bl.wa.solr.SolrFields;
+import uk.bl.wa.solr.SolrRecord;
+
+/**
+ * @author Andrew Jackson <Andrew.Jackson@bl.uk>
+ *
+ */
+public class HTMLAnalyserTest {
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+    // NOTE: The number of extract links is 4. This is technically correct, but one of the links are the empty String.
+    //       It is not obvious what the value of keeping track of empty links is, so it should be considered to
+    //       remove those links. From a larger perspective, this could be argues for all fields, so maybe the check
+    //       for the empty String should be done at the SolrRecord level.
+	@Test
+    public void testLinksExtraction() throws IOException {
+        final URL SAMPLE_RESOURCE = Thread.currentThread().getContextClassLoader().getResource("links_extract.html");
+        assertNotNull("The sample file should be resolved", SAMPLE_RESOURCE);
+        final File SAMPLE = new File(SAMPLE_RESOURCE.getFile());
+
+        final URL CONF_RESOURCE = Thread.currentThread().getContextClassLoader().getResource("links_extract.conf");
+        assertNotNull("The config file should be resolved", CONF_RESOURCE);
+        final File CONF = new File(CONF_RESOURCE.getFile());
+        Config config = ConfigFactory.parseFile(CONF);
+        HTMLAnalyser ha = new HTMLAnalyser(config);
+        Map<String, Object> core = new HashMap<String, Object>();
+        core.put("subject-uri", "NotPresent");
+        core.put("ip-address", "192.168.1.10");
+        core.put("creation-date", "Invalid");
+        core.put("content-type", "text/html");
+        core.put("length", Long.toString(SAMPLE.length()));
+        core.put("version", "InvalidVersion");
+        core.put("absolute-offset", "0");
+        ArchiveRecordHeader header = new ARCRecordMetaData("invalid", core);
+        SolrRecord solr = new SolrRecord();
+        InputStream in = new BufferedInputStream(new FileInputStream(SAMPLE), (int) SAMPLE.length());
+        in.mark((int) SAMPLE.length());
+        ha.analyse(header, in, solr);
+        assertEquals("The number of links should be correct",
+                     4, solr.getField(SolrFields.SOLR_LINKS).getValueCount());
+    }
+}

--- a/warc-indexer/src/test/java/uk/bl/wa/analyser/payload/HTMLAnalyserTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/analyser/payload/HTMLAnalyserTest.java
@@ -43,7 +43,7 @@ import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
 
 /**
- * @author Andrew Jackson <Andrew.Jackson@bl.uk>
+ * @author Toke Eskildsen <te@statsbiblioteket.dk>
  *
  */
 public class HTMLAnalyserTest {
@@ -55,10 +55,7 @@ public class HTMLAnalyserTest {
 	public void setUp() throws Exception {
 	}
 
-    // NOTE: The number of extract links is 4. This is technically correct, but one of the links are the empty String.
-    //       It is not obvious what the value of keeping track of empty links is, so it should be considered to
-    //       remove those links. From a larger perspective, this could be argues for all fields, so maybe the check
-    //       for the empty String should be done at the SolrRecord level.
+    // NOTE: The number of extract links is 3. This is correct as the empty String shuld be discarded.
 	@Test
     public void testLinksExtraction() throws IOException {
         final URL SAMPLE_RESOURCE = Thread.currentThread().getContextClassLoader().getResource("links_extract.html");
@@ -84,6 +81,6 @@ public class HTMLAnalyserTest {
         in.mark((int) SAMPLE.length());
         ha.analyse(header, in, solr);
         assertEquals("The number of links should be correct",
-                     4, solr.getField(SolrFields.SOLR_LINKS).getValueCount());
+                     3, solr.getField(SolrFields.SOLR_LINKS).getValueCount());
     }
 }

--- a/warc-indexer/src/test/resources/links_extract.conf
+++ b/warc-indexer/src/test/resources/links_extract.conf
@@ -1,0 +1,148 @@
+{
+    "warc" : {
+        "title" : "Default indexer config."
+        # Indexing configuration:
+        "index" : {
+            # What to extract:
+            "extract" : {
+                # Maximum payload size allowed to be kept wholly in RAM:
+                "inMemoryThreshold" : 10M,
+                # Maximum payload size that will be serialised out to disk instead of held in RAM:
+                "onDiskThreshold" : 100M,
+                
+                # Content to extract
+                "content" : {
+                    # Should we index the content body text?
+                    "text" : true,
+                    
+                    # Should we store the content body text?
+                    "text_stored" : true,
+                    
+                    # Extract list of elements used in HTML:
+                    "elements_used" : true,
+                    
+                    # Extract potential PDF problems using Apache PDFBox Preflight:
+                    "extractApachePreflightErrors" : true,
+                    
+                    # Extract image features:
+                    "images" : {
+                        "enabled" : true,
+                        "maxSizeInBytes" : 1M,
+                    	"detectFaces" : true,
+                    	"dominantColours" : true,
+                        # The random sampling rate:
+                        # (where '1' means 'extract from all images', 
+                        # and '100' would mean 'extract from 1 out of every 100 images')
+                        "analysisSamplingRate": 10
+                    }
+                    
+                    # Extract the first bytes of the file (for shingling):
+                    "first_bytes" : {
+                        # Enabled?
+                        "enabled" : true,
+                        # Number of bytes to extract (>=4 to allow content_ffb to work):
+                        "num_bytes" : 32
+                    }
+                },
+                
+                # Which linked entities to extract:
+                "linked" : {
+                    "resources" : true,
+                    "hosts" : true,
+                    "domains" : true
+                },
+                
+                # Restrict record types:
+                "record_type_include" : [
+                    response, revisit
+                ],
+                
+                # Restrict response codes:
+                # works by matches starting with the characters, so "2" will match 2xx:
+                "response_include" : [
+                    "2"
+                ],
+    
+                # Restrict protocols:
+                "protocol_include" : [
+                    http,
+                    https
+                ],
+   
+                # URLs to skip, e.g. ['robots.txt'] ???
+                "url_exclude" : [],
+            },
+            
+            # Parameters relating to format identification:   
+            "id" : {
+                # Allow tools to infer format from the resource URI (file extension):
+                "useResourceURI" : true
+    
+                # DROID-specific config:
+                "droid" : {
+                    "enabled" : true,
+                    "useBinarySignaturesOnly" : false
+                },
+            },
+            
+            # Parameters to control Apache Tika behaviour
+            "tika" : {
+                # Maximum length of text to extract:
+                "max_text_length" : 512K,
+                # Should we use the 'boilerpipe' text extractor?:
+                "use_boilerpipe": false,
+                # The parse timeout (for when Tika gets stuck):
+                "parse_timeout" : 300000,
+                # Formats to avoid processing
+                "exclude_mime" : [
+                    "x-tar",
+                    "x-gzip",
+                    "bz",
+                    "lz",
+                    "compress",
+                    "zip",
+                    "javascript",
+                    "css",
+                    "octet-stream"
+                ],
+                # Should we extract all the available metadata:
+                "extract_all_metadata": false
+            },
+            
+            # Parameters to control the exclusion of results from the indexing process:
+            "exclusions" : {
+                # Exclusion enabled?
+                "enabled" : false,
+                # Default check interval before reloading the exclusions file, in seconds:
+                "check_interval" : 600,
+                # Exclusion URI/SURT prefix file:
+                "file" : "/path/to/exclude.txt"
+            }
+        },
+        
+        # Solr configuration:
+        "solr" : {
+            # Use the hash+url as the ID for the documents
+            "use_hash_url_id": true
+            # Check SOLR for duplicates during indexing:
+            "check_solr_for_duplicates": false
+            # Server configuration:
+            "server" : "http://localhost:8080/solr/discovery",
+            # Solr document batch size for submissions:
+            "batch_size" : 50,
+            # Number of threads per Solr client:
+            "num_threads" : 1,
+            # Is this a dummy-run? (i.e. should we NOT post to SOLR?)
+            "dummy_run" : false,
+            # Disable explicit commit
+            "disablecommit" : false,
+        },
+        
+        # HTTP Proxy to use when talking to Solr (if any):
+        "http_proxy" : {
+            #"host" : explorer.bl.uk,
+            #"port" : 3127
+        }
+    }
+}
+    

--- a/warc-indexer/src/test/resources/links_extract.html
+++ b/warc-indexer/src/test/resources/links_extract.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+    <title>Page for link extraction checking</title>
+</head>
+<body>
+<h1>See HTMLAnalyserTest for test code</h1>
+<p>
+    <ul>
+    <li><a href="#internal">Internal</a></li>
+    <li><a href="http://example.org/sub1.html">External</a></li>
+    <li><a href="http://example.org/sub2.html#anchor">External with anchor</a></li>
+    <li><a href="http://example.org/sub1.html">External duplicate</a></li>
+    <li><a href="http://example.org/forgot to escape spaces.html">External with spaces</a></li>
+    <li><a href="">Empty link</a></li>
+    </ul>
+
+</p>
+</body>
+</html>


### PR DESCRIPTION
Encoding lists of links as a single space-separated String introduces a performance penalty and results in errors when there are spaces in the links themselves. This patch switches to String[] as the transport mechanism. Unit test included.