### PR TITLE
Empty terms should not be added

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Performance instrumentation [#46](https://github.com/ukwa/webarchive-discovery/pull/46)
 * Reduced schema to required fields only [#49](https://github.com/ukwa/webarchive-discovery/pull/49)
 * The TikaInputStream must be closed to closed to clean up temp files [#50](https://github.com/ukwa/webarchive-discovery/pull/50)
+* Empty terms should not be added [#55](https://github.com/ukwa/webarchive-discovery/pull/55)
 
 2.0.0
 -----

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecord.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecord.java
@@ -145,8 +145,8 @@ public class SolrRecord implements Serializable {
 	 * @param value
 	 */
 	public void addField( String solr_property, String value ) {
-		if( value != null )
-			doc.addField( solr_property, sanitizeString(solr_property, value) );
+		if( value != null && !(value = sanitizeString(solr_property, value)).isEmpty())
+			doc.addField( solr_property, value );
 	}
 
 	/**
@@ -156,8 +156,8 @@ public class SolrRecord implements Serializable {
 	 * @param value
 	 */
 	public void setField( String solr_property, String value ) {
-		if( value != null )
-			doc.setField( solr_property, sanitizeString(solr_property, value) );
+        if( value != null && !(value = sanitizeString(solr_property, value)).isEmpty())
+			doc.setField( solr_property, value );
 	}
 	
 	/**
@@ -167,6 +167,9 @@ public class SolrRecord implements Serializable {
 	 * @param value
 	 */
 	public void mergeField( String solr_property, String value ) {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
 		Map<String, String> operation = new HashMap<String, String>();
 		operation.put("add", value );
 		doc.addField( solr_property, operation);


### PR DESCRIPTION
If the query sanitizer removes all characters for the input String, the empty String is currently added to the Solr index. The empty-term noise is especially visible with sorting and faceting.

This patch adds a simple check and discards the field update if there are no content.