### PR TITLE
Optional link and URL normalisation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
   * The Tika language detection speed improvement [Tika #29](https://github.com/apache/tika/pull/29) has been temporarily copied in order to benefit from the speed without having to use the yet-unreleased Tika 1.8.
   * Some trivial speed-improvements were added by replacing String.replaceAll with precompiled Patterns.
   * Extraction of meta-data from the ARC path has been added: ARCNameAnalyser. The unit test demonstrates how job-names and other data can be extracted.
-
+  * Optional link and URL normalisation [yika #60](https://github.com/ukwa/webarchive-discovery/pull/60) 
 
 2.0.0
 -----

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
@@ -50,7 +50,7 @@ import uk.bl.wa.util.Instrument;
 public class HTMLAnalyser extends AbstractPayloadAnalyser {
 	private static Log log = LogFactory.getLog( HTMLAnalyser.class );
 
-	private HtmlFeatureParser hfp = new HtmlFeatureParser();
+	private HtmlFeatureParser hfp;
 	private boolean extractLinkDomains;
 	private boolean extractLinkHosts;
 	private boolean extractLinks;
@@ -65,6 +65,7 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 		log.info("HTML - Extract domain links " + this.extractLinkDomains);
 		this.extractElementsUsed = conf.getBoolean( "warc.index.extract.content.elements_used" );
 		log.info("HTML - Extract elements used " + this.extractElementsUsed);
+        hfp = new HtmlFeatureParser(conf);
 	}
 	/**
 	 *  JSoup link extractor for (x)html, deposit in 'links' field.

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
@@ -34,6 +34,8 @@ public interface SolrFields {
 	public static final String ID = "id";
 	public static final String ID_LONG = "id_long";
 	public static final String SOLR_URL = "url";
+    // Intended for building links-graphs. Normalised the same way as SOLR_LINKS
+    public static final String SOLR_URL_NORMALISED = "url_norm";
 	public static final String SOURCE_FILE = "source_file_s";
 	// public static final String SOURCE_FILE_OFFSET = "source_file_offset";
 	
@@ -126,5 +128,5 @@ public interface SolrFields {
 	public static final String IMAGE_FACES_COUNT = "image_faces_count";
 	public static final String IMAGE_COLOURS = "image_colours";
 	public static final String IMAGE_DOMINANT_COLOUR = "image_dominant_colour";
-	
+
 }

--- a/warc-indexer/src/main/resources/reference.conf
+++ b/warc-indexer/src/main/resources/reference.conf
@@ -66,6 +66,7 @@
                 
                 # Which linked entities to extract:
                 "linked" : {
+                    "normalise" : false,
                     "resources" : false,
                     "hosts" : true,
                     "domains" : true

--- a/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
@@ -113,6 +113,7 @@
    <field name="author" type="string" indexed="true" stored="true"/>
    <field name="keywords" type="text_general" indexed="true" stored="true"/>
    <field name="url" type="string" indexed="true" stored="true"/>
+   <field name="url_norm" type="string" indexed="true" stored="true"/>
    <field name="content_type" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="last_modified" type="date" indexed="true" stored="true"/>
    <field name="last_modified_year" type="string" indexed="true" stored="true"/>

--- a/warc-indexer/src/test/java/uk/bl/wa/parsers/HtmlFeatureParserTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/parsers/HtmlFeatureParserTest.java
@@ -30,7 +30,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
+import com.typesafe.config.ConfigFactory;
 import junit.framework.Assert;
 
 import org.apache.tika.exception.TikaException;
@@ -78,6 +81,37 @@ public class HtmlFeatureParserTest {
 		stream.reset();
 		innerBasicParseTest(stream, baseUri, 2);
 	}
+
+    @Test
+    public void testNormalise() {
+        final String[][] TESTS = new String[][] { // Expected, input
+//                {"http://example.org", "http://www.example.org"},
+                {"http://example.org/foo", "http://www.example.org/foo"},
+                {"http://example.org", "http://example.org"},
+                {"http://example.org", "http://example.org?"},
+                //{"http://example.org", "https://example.org?"},
+                {"http://example.org", "http://user@example.org"},
+                {"http://example.org/foo", "http://user@www.example.org/foo"},
+//                {"http://example.org", "http://user@www.example.org"},
+                {"http://example.org", "http://eXample.org"},
+                {"http://example.org", "http://example.ORG"},
+//                {"http://example.org", "http://example.org/"},
+//                {"http://example.org", "http://example.org/index.html"}
+        };
+        Map<String, String> normMap = new HashMap<String, String>();
+        normMap.put(HtmlFeatureParser.CONF_LINKS_NORMALISE, "true");
+        HtmlFeatureParser normParser = new HtmlFeatureParser(ConfigFactory.parseMap(normMap));
+
+        normMap.put(HtmlFeatureParser.CONF_LINKS_NORMALISE, "false");
+        HtmlFeatureParser skipParser = new HtmlFeatureParser(ConfigFactory.parseMap(normMap));
+
+        for (String[] test: TESTS) {
+            Assert.assertEquals("Normalisation of '" + test[1] + "'",
+                                test[0], normParser.normaliseLink(test[1]));
+            Assert.assertEquals("Non-normalisation of '" + test[1] + "'",
+                                test[1], skipParser.normaliseLink(test[1]));
+        }
+    }
 
 	private static void printMetadata(Metadata metadata) {
 		for (String name : metadata.names()) {


### PR DESCRIPTION
This patch optionally normalises links extracted from HTML as well as the URL from the WAR(C). The normaliser uses the AggressiveUrlCanonicalizer.

This patch does not convert to SURT format. This might be an idea for a future feature, but care must be taken not to mix this with standard host- and domain-links.