### PR TITLE
Extend annotations mechanism to allow source file prefix as a scope

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/annotation/Annotations.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/annotation/Annotations.java
@@ -73,7 +73,7 @@ public class Annotations {
 		collections.put("plus1", new HashMap<String, UriCollection>());
 		collections.put("root", new HashMap<String, UriCollection>());
 		collections.put("subdomains", new HashMap<String, UriCollection>());
-		collections.put("source_file_prefix", new HashMap<String, UriCollection>());
+		collections.put("source_file_matches", new HashMap<String, UriCollection>());
 
 		// An the date ranges:
 		collectionDateRanges = new HashMap<String, DateRange>();

--- a/warc-indexer/src/main/java/uk/bl/wa/annotation/Annotations.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/annotation/Annotations.java
@@ -73,6 +73,7 @@ public class Annotations {
 		collections.put("plus1", new HashMap<String, UriCollection>());
 		collections.put("root", new HashMap<String, UriCollection>());
 		collections.put("subdomains", new HashMap<String, UriCollection>());
+		collections.put("source_file_prefix", new HashMap<String, UriCollection>());
 
 		// An the date ranges:
 		collectionDateRanges = new HashMap<String, DateRange>();

--- a/warc-indexer/src/main/java/uk/bl/wa/annotation/Annotator.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/annotation/Annotator.java
@@ -179,18 +179,18 @@ public class Annotator {
 				updateCollections(subdomains.get(key), solr, crawl_dates);
 			}
 		}
-		// "All source_file that match this source_file_prefix"
+		// "All source_file that match this source_file_matches"
 		Pattern pattern;
 		Matcher matcher;
 		String sourceFile = (String) solr.getField(SolrFields.SOURCE_FILE).getValue();
-		HashMap<String, UriCollection> sourceFilePrefix = this.annotations
-				.getCollections().get("source_file_prefix");
-		for (String key : sourceFilePrefix.keySet()) {
-			LOG.debug("Applying source_file_prefix annotations for: " + key);
+		HashMap<String, UriCollection> sourceFileMatches = this.annotations
+				.getCollections().get("source_file_matches");
+		for (String key : sourceFileMatches.keySet()) {
+			LOG.debug("Applying source_file_matches annotations for: " + key);
 			pattern = Pattern.compile(key);
 			matcher = pattern.matcher(sourceFile);
 			while (matcher.find()) {
-				updateCollections(sourceFilePrefix.get(key), solr, crawl_dates);
+				updateCollections(sourceFileMatches.get(key), solr, crawl_dates);
 			}
 		}
 

--- a/warc-indexer/src/main/java/uk/bl/wa/annotation/Annotator.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/annotation/Annotator.java
@@ -41,6 +41,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.logging.Log;
@@ -175,6 +177,20 @@ public class Annotator {
             }
 			if( host.equals( domain ) || host.endsWith( "." + domain ) ) {
 				updateCollections(subdomains.get(key), solr, crawl_dates);
+			}
+		}
+		// "All source_file that match this source_file_prefix"
+		Pattern pattern;
+		Matcher matcher;
+		String sourceFile = (String) solr.getField(SolrFields.SOURCE_FILE).getValue();
+		HashMap<String, UriCollection> sourceFilePrefix = this.annotations
+				.getCollections().get("source_file_prefix");
+		for (String key : sourceFilePrefix.keySet()) {
+			LOG.debug("Applying source_file_prefix annotations for: " + key);
+			pattern = Pattern.compile(key);
+			matcher = pattern.matcher(sourceFile);
+			while (matcher.find()) {
+				updateCollections(sourceFilePrefix.get(key), solr, crawl_dates);
 			}
 		}
 

--- a/warc-indexer/src/test/java/uk/bl/wa/annotation/AnnotationsTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/annotation/AnnotationsTest.java
@@ -78,7 +78,7 @@ public class AnnotationsTest {
 								new String[] { "Crowdsourcing" }));
 		//
 		ann.getCollections()
-				.get("source_file_prefix")
+				.get("source_file_matches")
 				.put("flashfrozen-",
 						new UriCollection("Wikipedia", new String[] {
 								"Wikipedia", "Wikipedia|Main Site" },

--- a/warc-indexer/src/test/java/uk/bl/wa/annotation/AnnotationsTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/annotation/AnnotationsTest.java
@@ -76,6 +76,13 @@ public class AnnotationsTest {
 						new UriCollection("Wikipedia",
 								new String[] { "Wikipedia" },
 								new String[] { "Crowdsourcing" }));
+		//
+		ann.getCollections()
+				.get("source_file_prefix")
+				.put("flashfrozen-",
+						new UriCollection("Wikipedia", new String[] {
+								"Wikipedia", "Wikipedia|Main Site" },
+								new String[] { "Crowdsourcing" }));
 		// Date ranges:
 		ann.getCollectionDateRanges().put("Wikipedia",
 				new DateRange(null, null));

--- a/warc-indexer/src/test/java/uk/bl/wa/annotation/AnnotatorTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/annotation/AnnotatorTest.java
@@ -63,12 +63,13 @@ public class AnnotatorTest {
 
 	@Test
 	public void testApplyAnnotations() throws URIException, URISyntaxException {
-        innerTestApplyAnnotations("http://en.wikipedia.org/wiki/Mona_Lisa", 4);
-        innerTestApplyAnnotations("http://en.wikipedia.org/", 3);
-        innerTestApplyAnnotations("http://www.wikipedia.org/", 2);
+		innerTestApplyAnnotations("http://en.wikipedia.org/wiki/Mona_Lisa", "", 4);
+		innerTestApplyAnnotations("http://en.wikipedia.org/", "", 3);
+		innerTestApplyAnnotations("http://www.wikipedia.org/", "", 2);
+		innerTestApplyAnnotations("http://www.wikipedia.org/", "flashfrozen-jwat-recompressed.warc.gz", 3);
 	}
 
-	private void innerTestApplyAnnotations(String uriString, int expected)
+	private void innerTestApplyAnnotations(String uriString, String sourceFile, int expected)
 			throws URIException, URISyntaxException {
 		//
 		URI uri = URI.create(uriString);
@@ -88,6 +89,7 @@ public class AnnotatorTest {
 		Date d = calendar.getTime();
 		solr.setField(SolrFields.CRAWL_DATE, WARCIndexer.formatter.format(d));
 		solr.setField(SolrFields.SOLR_URL, uri);
+		solr.setField(SolrFields.SOURCE_FILE, sourceFile);
 		//
 		annotator.applyAnnotations(uri, solr);
 		Annotator.prettyPrint(System.out, solr);

--- a/warc-indexer/src/test/java/uk/bl/wa/indexer/WARCIndexerEmbeddedSolrTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/indexer/WARCIndexerEmbeddedSolrTest.java
@@ -122,6 +122,7 @@ public class WARCIndexerEmbeddedSolrTest {
         document.addField("id", "1");
 		document.addField("title", "my title");
         document.addField( "url", url );
+		document.addField("source_file", "source_file");
 
         System.out.println("Adding document: "+document);
         server.add(document);
@@ -152,11 +153,12 @@ public class WARCIndexerEmbeddedSolrTest {
 		// Prevent the indexer from attempting to query Solr:
 		windex.setCheckSolrForDuplicates(false);
 		
-		ArchiveReader reader = ArchiveReaderFactory.get( new File(testWarc) );
+		File inFile = new File(testWarc);
+		ArchiveReader reader = ArchiveReaderFactory.get(inFile);
 		Iterator<ArchiveRecord> ir = reader.iterator();
 		while( ir.hasNext() ) {
 			ArchiveRecord rec = ir.next();
-			SolrRecord doc = windex.extract("",rec);
+			SolrRecord doc = windex.extract(inFile.getName(), rec);
 			if( doc != null ) {
 				//System.out.println(doc.toXml());
 				//break;

--- a/warc-indexer/src/test/resources/annotations/mona-lisa-annotations.json
+++ b/warc-indexer/src/test/resources/annotations/mona-lisa-annotations.json
@@ -22,6 +22,13 @@
       }
     },
     "plus1" : {
+    },
+    "source_file_prefix" : {
+      "flashfrozen-" : {
+        "collection" : "Wikipedia",
+        "collections" : [ "Wikipedia", "Wikipedia|Main Site" ],
+        "subject" : [ "Crowdsourcing" ]
+      }
     }
   },
   "collectionDateRanges" : {

--- a/warc-indexer/src/test/resources/annotations/mona-lisa-annotations.json
+++ b/warc-indexer/src/test/resources/annotations/mona-lisa-annotations.json
@@ -23,7 +23,7 @@
     },
     "plus1" : {
     },
-    "source_file_prefix" : {
+    "source_file_matches" : {
       "flashfrozen-" : {
         "collection" : "Wikipedia",
         "collections" : [ "Wikipedia", "Wikipedia|Main Site" ],


### PR DESCRIPTION
A proposition for issue #88 
Now if you use the annotations mechanism, if the name of your warc file contains a source_file_prefix (from the annotation file), the corresponding informations will be add to the solr document.