### PR TITLE
Mine stats

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/ARCNameAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/ARCNameAnalyser.java
@@ -95,7 +95,6 @@ public class ARCNameAnalyser extends AbstractPayloadAnalyser {
 
     @Override
    	public void analyse(ArchiveRecordHeader header, InputStream tikainput, SolrRecord solr) {
-        final long start = System.nanoTime();
         final String name = header.getReaderIdentifier();
         if (name == null || name.isEmpty()) {
             log.debug("No name present for ARC, skipping analyse");
@@ -106,9 +105,6 @@ public class ARCNameAnalyser extends AbstractPayloadAnalyser {
                 break; // Only one rule match
             }
         }
-
-        Instrument.timeRel("WARCPayloadAnalyzers.analyze#total",
-                           "ARCNameAnalyzer.analyze", start);
    	}
 
     public List<Rule> getRules() {

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/WARCPayloadAnalysers.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/WARCPayloadAnalysers.java
@@ -110,6 +110,7 @@ public class WARCPayloadAnalysers {
 			image = new ImageAnalyser(conf);
 		}
         arcname = new ARCNameAnalyser(conf);
+		Instrument.createSortedStat("WARCPayloadAnalyzers.analyze#droid", Instrument.SORT.avgtime, 5);
 	}
 	
 	public void analyse(ArchiveRecordHeader header, InputStream tikainput, SolrRecord solr) {
@@ -169,6 +170,9 @@ public class WARCPayloadAnalysers {
 				// Run Droid:
 				MediaType mt = dd.detect( tikainput, metadata );
 				solr.addField( SolrFields.CONTENT_TYPE_DROID, mt.toString() );
+				Instrument.timeRel("WARCPayloadAnalyzers.analyze#droid",
+								   "WARCPayloadAnalyzers.analyze#droid_type=" + mt.toString(),
+								   droidStart);
 			} catch( Exception i ) {
 				// Note that DROID complains about some URLs with an IllegalArgumentException.
 				log.error(i + ": " + i.getMessage() + ";dd; " + header.getUrl()
@@ -176,6 +180,7 @@ public class WARCPayloadAnalysers {
 			}
             Instrument.timeRel("WARCPayloadAnalyzers.analyze#total",
                                "WARCPayloadAnalyzers.analyze#droid", droidStart);
+
 		}
 
         // Parse ARC name

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -223,7 +223,7 @@ public class WARCIndexer {
 		this.txa = new TextAnalysers(conf);
 
 		// We want stats for the 20 resource types that we spend the most time processing
-		Instrument.createSortedStat("WARCIndexer#MIME_Breakdown", Instrument.SORT.time, 20);
+		Instrument.createSortedStat("WARCIndexer#content_types", Instrument.SORT.time, 20);
 
 		// Log so it's clear this completed ok:
 		log.info("Initialisation of WARCIndexer complete.");
@@ -581,8 +581,10 @@ public class WARCIndexer {
 		}
 		Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#solrdocCreation",
                      "WARCIndexer.extract#total", start);
-		Instrument.timeRel("WARCIndexer#MIME_Breakdown",
-                     "WARCIndexer#MIME_" + solr.getField(SolrFields.CONTENT_TYPE_SERVED), start);
+		String servedType = solr.getField(SolrFields.CONTENT_TYPE_SERVED).toString();
+		Instrument.timeRel("WARCIndexer#content_types",
+                     "WARCIndexer#" + (servedType.contains(";") ? servedType.split(";")[0] : servedType),
+						   start);
         return solr;
 	}
 

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -221,7 +221,10 @@ public class WARCIndexer {
 		log.info("Setting up analysers...");
 		this.wpa = new WARCPayloadAnalysers(conf);
 		this.txa = new TextAnalysers(conf);
-		
+
+		// We want stats for the 20 resource types that we spend the most time processing
+		Instrument.createSortedStat("WARCIndexer#MIME_Breakdown", Instrument.SORT.time, 20);
+
 		// Log so it's clear this completed ok:
 		log.info("Initialisation of WARCIndexer complete.");
 	}
@@ -576,8 +579,10 @@ public class WARCIndexer {
 				}
 			}
 		}
-        Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#solrdocCreation",
-                           "WARCIndexer.extract#total", start);
+		Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#solrdocCreation",
+                     "WARCIndexer.extract#total", start);
+		Instrument.timeRel("WARCIndexer#MIME_Breakdown",
+                     "WARCIndexer#MIME_" + solr.getField(SolrFields.CONTENT_TYPE_SERVED), start);
         return solr;
 	}
 

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -585,6 +585,7 @@ public class WARCIndexer {
 		Instrument.timeRel("WARCIndexer#content_types",
                      "WARCIndexer#" + (servedType.contains(";") ? servedType.split(";")[0] : servedType),
 						   start);
+		Instrument.timeRel("WARCIndexer#content_types", start);
         return solr;
 	}
 

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -275,6 +275,7 @@ public class WARCIndexerCommand {
                            "WARCIndexerCommand.parseWarcFiles#startup", start);
 		// Loop through each Warc files
         for (int arcsIndex = 0; arcsIndex < args.length; arcsIndex++) {
+			final long arcStart = System.nanoTime();
             String inputFile = args[arcsIndex];
             if (!disableCommit) {
                 // Commit to make sure index is up to date:
@@ -337,7 +338,7 @@ public class WARCIndexerCommand {
             }
             curInputFile++;
             Instrument.timeRel("WARCIndexerCommand.main#total",
-                               "WARCIndexerCommand.parseWarcFiles#fullarcprocess", start);
+                               "WARCIndexerCommand.parseWarcFiles#fullarcprocess", arcStart);
             Instrument.log(arcsIndex < args.length-1); // Don't log the last on info to avoid near-duplicate logging
         }
 

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -80,7 +80,9 @@ import uk.bl.wa.util.Instrument;
 public class WARCIndexerCommand {
 	
 	private static Log log = LogFactory.getLog(WARCIndexerCommand.class);
-	
+	static {
+		Instrument.init();
+	}
 
 	private static final String CLI_USAGE = "[-o <output dir>] [-s <Solr instance>] [-t] <include text> [-r] <root/slash pages only> [-b <batch-submissions size>] [WARC File List]";
 	private static final String CLI_HEADER = "WARCIndexer - Extracts metadata and text from Archive Records";
@@ -315,7 +317,7 @@ public class WARCIndexerCommand {
                     doc.addParseException(e);
                 }
 
-                Instrument.timeRel("WARCIndexerCommand.main#total",
+                Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#fullarcprocess",
                                    "WARCIndexerCommand.parseWarcFiles#solrdocCreation", recordStart);
                 if (doc != null) {
                     final long updateStart = System.nanoTime();
@@ -332,7 +334,7 @@ public class WARCIndexerCommand {
                         }
                         recordCount++;
                     }
-                    Instrument.timeRel("WARCIndexerCommand.main#total",
+                    Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#fullarcprocess",
                                        "WARCIndexerCommand.parseWarcFiles#docdelivery", updateStart);
                 }
             }
@@ -343,7 +345,12 @@ public class WARCIndexerCommand {
         }
 
 		// Submit any remaining docs:
-		checkSubmission(solrWeb, docs, batchSize, true);
+		if (docs.size() > 0) {
+			final long updateStart = System.nanoTime();
+			checkSubmission(solrWeb, docs, batchSize, true);
+			Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#fullarcprocess",
+                      "WARCIndexerCommand.parseWarcFiles#docdelivery", updateStart);
+		}
         if (!disableCommit) {
             // Commit the updates:
             commit(solrWeb);

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecord.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecord.java
@@ -94,7 +94,8 @@ public class SolrRecord implements Serializable {
 		} catch (CharacterCodingException e) {
 			return "";
 		} finally {
-            Instrument.timeRel("SolrRecord.removeControlCharacters#total", start);
+            Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#solrdocCreation",
+							   "SolrRecord.removeControlCharacters#total", start);
         }
 	}
     private static final Pattern SPACE_PATTERN = Pattern.compile("\\p{Space}");

--- a/warc-indexer/src/main/java/uk/bl/wa/util/Instrument.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Instrument.java
@@ -47,6 +47,14 @@ public class Instrument {
     private static final long classStart = System.nanoTime();
 
     /**
+     * Init must be called as early as possible as this triggers class-load and thus the setting of {@link #classStart}
+     * which is used for calculating relative time usage throughout the project.
+     * Multiple calls have no effect.
+     */
+    public static void init() {
+        log.debug("Initialized with classStart " + classStart + "ns and init call " + System.nanoTime() + "ns");
+    }
+    /**
      * Increment the total time for the tracker with the given ID.
      * The delta is calculated with {@code System.nanotime() - nanoStart}.
      * @param id        id for a tracker. If it does not exist, it will be created.

--- a/warc-indexer/src/test/java/uk/bl/wa/util/InstrumentTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/InstrumentTest.java
@@ -31,12 +31,24 @@ public class InstrumentTest extends TestCase {
 
     // Not a real test as it requires visual inspection
     public void testHierarchical() {
+        Instrument.clear();
         Instrument.time("top", 123456);
         Instrument.time("top", "mid1", 123457);
         Instrument.time("top", "mid2", 123459);
         Instrument.time("mid1", "bottom", 123460);
         assertTrue("There should be a double indent in\n" + Instrument.getStats(),
                    Instrument.getStats().contains("    "));
+    }
+
+    public void testChildSortAndLimit() {
+        Instrument.clear();
+        Instrument.createSortedStat("top", Instrument.SORT.time, 2);
+        Instrument.time("top", 123456);
+        Instrument.time("top", "mid1", 123457);
+        Instrument.time("top", "mid2", 134459);
+        Instrument.time("top", "mid3", 145500);
+        assertFalse("The output should not contain 'mid1': It is the fastest and the order is 'time' with a limit if 2",
+                    Instrument.getStats().contains("mid1"));
     }
 
 }

--- a/warc-indexer/src/test/java/uk/bl/wa/util/InstrumentTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/InstrumentTest.java
@@ -40,15 +40,58 @@ public class InstrumentTest extends TestCase {
                    Instrument.getStats().contains("    "));
     }
 
-    public void testChildSortAndLimit() {
+    public void testChildTimeSortAndLimit() {
         Instrument.clear();
         Instrument.createSortedStat("top", Instrument.SORT.time, 2);
         Instrument.time("top", 123456);
-        Instrument.time("top", "mid1", 123457);
+        Instrument.time("top", "mid1", 925457);
         Instrument.time("top", "mid2", 134459);
+        Instrument.time("top", "mid2", 334459);
         Instrument.time("top", "mid3", 145500);
-        assertFalse("The output should not contain 'mid1': It is the fastest and the order is 'time' with a limit if 2",
+        Instrument.time("top", "mid3", 145500);
+        Instrument.time("top", "mid3", 145500);
+        assertTrue("Sanity check: The output should contain 'mid2'", Instrument.getStats().contains("mid2"));
+        assertFalse("The output should not contain 'mid3' as it is the fastest and the order is 'time' with limit 2",
+                    Instrument.getStats().contains("mid3"));
+        log.info(Instrument.getStats());
+    }
+
+    public void testTimeSortIntOverflow() {
+        Instrument.clear();
+        Instrument.createSortedStat("top", Instrument.SORT.time, 9999);
+        Instrument.setAbsolute("top", "a", 69560000L, 2);
+        Instrument.setAbsolute("top", "b", 24590000L, 1);
+        Instrument.setAbsolute("top", "c", 16830910000L, 1224);
+        Instrument.setAbsolute("top", "d", 12452050000L, 1129);
+        log.info(Instrument.getStats());
+    }
+
+    public void testChildTimeSortOrder() {
+        Instrument.clear();
+        Instrument.createSortedStat("top", Instrument.SORT.time, 9999);
+        Instrument.time("top", 123456);
+        Instrument.time("top", "mid1", 925457);
+        Instrument.time("top", "mid2", 134459);
+        Instrument.time("top", "mid3", 445500);
+        Instrument.time("top", "mid5", 245500);
+        
+        log.info(Instrument.getStats());
+    }
+
+    public void testChildCountSortAndLimit() {
+        Instrument.clear();
+        Instrument.createSortedStat("top", Instrument.SORT.count, 2);
+        Instrument.time("top", 123456);
+        Instrument.time("top", "mid1", 925457);
+        Instrument.time("top", "mid2", 134459);
+        Instrument.time("top", "mid2", 334459);
+        Instrument.time("top", "mid3", 145500);
+        Instrument.time("top", "mid3", 145500);
+        Instrument.time("top", "mid3", 145500);
+        assertTrue("Sanity check: The output should contain 'mid2'", Instrument.getStats().contains("mid2"));
+        assertFalse("The output should not contain 'mid1': It occurs only once  and the order is 'count' with limit 2",
                     Instrument.getStats().contains("mid1"));
+        log.info(Instrument.getStats());
     }
 
 }

--- a/warc-indexer/src/test/java/uk/bl/wa/util/InstrumentTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/InstrumentTest.java
@@ -38,6 +38,7 @@ public class InstrumentTest extends TestCase {
         Instrument.time("mid1", "bottom", 123460);
         assertTrue("There should be a double indent in\n" + Instrument.getStats(),
                    Instrument.getStats().contains("    "));
+        log.info(Instrument.getStats());
     }
 
     public void testChildTimeSortAndLimit() {


### PR DESCRIPTION
Adds performance breakdown of which types (as stated by the server) of files takes the longest to process. Sample output from a `warc-indexer`-run:
```
WARCIndexer#content_types(#=0, time=0.00ms, avg=0.00#/ms 0.00ms/#, 0.00%)
  WARCIndexer#content_type_served=text/html(#=1224, time=17780.81ms, avg=0.07#/ms 14.53ms/#, 53.09%)
  WARCIndexer#content_type_served=application/x-javascript(#=1129, time=14219.61ms, avg=0.08#/ms 12.59ms/#, 42.46%)
  WARCIndexer#content_type_served=image/jpeg(#=2, time=103.77ms, avg=0.02#/ms 51.88ms/#, 0.31%)
  WARCIndexer#content_type_served=text/plain(#=1, time=22.95ms, avg=0.04#/ms 22.95ms/#, 0.07%)
```