### PR TITLE
3.0 enhancements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,8 +27,11 @@
 * Use a single-valued primary `hash` field and move option of multiple values to `hashes` field [#95](https://github.com/ukwa/webarchive-discovery/issues/95)
 * Extend annotations mechanism to allow source file prefix as a scope [#96](https://github.com/ukwa/webarchive-discovery/pull/96)
 * And various minor bugfixes. See the [3.0.0 Release Milestone](https://github.com/ukwa/webarchive-discovery/milestone/6) for further details.
-
-
+* Source_file_path field added. (full path to warc-file)
+* Images (optional) Exif gps,version extraction and height/width  of images indexed. 
+* Images links exctrated to new field 
+* new solr field: index_time
+* Two new fields from warc-header: warc_key_id, warc_ip
 
 2.1.0
 -----

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
@@ -59,11 +59,12 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 	private boolean extractLinkHosts;
 	private boolean extractLinks;
 	private boolean extractElementsUsed;
-
+    private boolean extractImageLinks;
+	
 	private AggressiveUrlCanonicalizer canon = new AggressiveUrlCanonicalizer();
 
-	public HTMLAnalyser( Config conf ) {
-		this.extractLinks = conf.getBoolean( "warc.index.extract.linked.resources" );
+	public HTMLAnalyser( Config conf ) {			  		 
+	    this.extractLinks = conf.getBoolean( "warc.index.extract.linked.resources" );
 		log.info("HTML - Extract resource links " + this.extractLinks);
 		this.extractLinkHosts = conf.getBoolean( "warc.index.extract.linked.hosts" );
 		log.info("HTML - Extract host links " + this.extractLinkHosts);
@@ -71,6 +72,8 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 		log.info("HTML - Extract domain links " + this.extractLinkDomains);
 		this.extractElementsUsed = conf.getBoolean( "warc.index.extract.content.elements_used" );
 		log.info("HTML - Extract elements used " + this.extractElementsUsed);
+        this.extractImageLinks = conf.getBoolean( "warc.index.extract.linked.images" );
+	    log.info("HTML - Extract image links " + this.extractElementsUsed);
         hfp = new HtmlFeatureParser(conf);
 	}
 	/**
@@ -102,6 +105,17 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 		}
         Instrument.timeRel("HTMLAnalyzer.analyze#total", "HTMLAnalyzer.analyze#parser", start);
 
+        
+        //Process image links
+        if (extractImageLinks){
+          String[] imageLinks = metadata.getValues( HtmlFeatureParser.IMAGE_LINKS );
+          if (imageLinks != null){            
+            for( String link : imageLinks ) { 
+              solr.addField( SolrFields.SOLR_LINKS_IMAGES, link );
+            }
+          }                
+        }
+        
 		// Process links:
 		String[] links_list = metadata.getValues( HtmlFeatureParser.LINK_LIST );
 		if( links_list != null ) {

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
@@ -111,7 +111,8 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
           String[] imageLinks = metadata.getValues( HtmlFeatureParser.IMAGE_LINKS );
           if (imageLinks != null){            
             for( String link : imageLinks ) { 
-              solr.addField( SolrFields.SOLR_LINKS_IMAGES, link );
+              String urlNorm  = canon.canonicalize(link); 
+              solr.addField( SolrFields.SOLR_LINKS_IMAGES, urlNorm);
             }
           }                
         }
@@ -134,8 +135,10 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 					domains.add(ldomain);
 				}
 				// Also store actual resource-level links:
-				if( this.extractLinks )
-					solr.addField( SolrFields.SOLR_LINKS, link );
+				if( this.extractLinks ){
+				    String urlNorm  = canon.canonicalize(link); 
+					solr.addField( SolrFields.SOLR_LINKS, urlNorm );
+				}
 			}
 			// Store the data from the links:
 			if( this.extractLinkHosts ) {

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -25,6 +25,8 @@ package uk.bl.wa.indexer;
  */
 
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_TYPE;
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_ID;
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_IP;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -270,8 +272,8 @@ public class WARCIndexer {
 	 * @return
 	 * @throws IOException
 	 */
-	public SolrRecord extract( String archiveName, ArchiveRecord record, boolean isTextIncluded ) throws IOException {
-        final long start = System.nanoTime();
+	public SolrRecord extract( String archiveName, ArchiveRecord record, boolean isTextIncluded ) throws IOException {      
+	  final long start = System.nanoTime();
 		ArchiveRecordHeader header = record.getHeader();
 		SolrRecord solr = new SolrRecord(archiveName, header);
 		
@@ -284,8 +286,13 @@ public class WARCIndexer {
 					return null;
 				}
 				// Store WARC record type:
-				solr.setField(SolrFields.SOLR_RECORD_TYPE,
-						(String) header.getHeaderValue(HEADER_KEY_TYPE));
+				solr.setField(SolrFields.SOLR_RECORD_TYPE, (String) header.getHeaderValue(HEADER_KEY_TYPE));
+
+				//Store WARC-Record-ID
+				solr.setField(SolrFields.WARC_KEY_ID, (String) header.getHeaderValue(HEADER_KEY_ID));
+                solr.setField(SolrFields.WARC_IP, (String) header.getHeaderValue(HEADER_KEY_IP));
+				
+				
 			} else {
 				// else we're processing ARCs so nothing to filter and no
 				// revisits
@@ -659,7 +666,7 @@ public class WARCIndexer {
 			
 			solr.addField(SolrFields.HTTP_STATUS, Integer.toString(statusCodeInt));
 			for( Header h : httpHeaders ) {
-				// Get the type from the server
+			  // Get the type from the server
 				if (h.getName().equalsIgnoreCase(HttpHeaders.CONTENT_TYPE)
 						&& solr.getField(SolrFields.CONTENT_TYPE_SERVED) == null) {
 					String servedType = h.getValue();

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -329,8 +329,11 @@ public class WARCIndexer {
 
 			// Basic metadata:
 			solr.setField(SolrFields.SOURCE_FILE, archiveName);
-			solr.setField(SolrFields.SOURCE_FILE_OFFSET,
-					"" + header.getOffset());
+			solr.setField(SolrFields.SOURCE_FILE_OFFSET,"" + header.getOffset());
+			solr.setField(SolrFields.SOURCE_FILE_PATH, header.getReaderIdentifier()); //Full path of file
+			
+			
+			
             byte[] url_md5digest = md5
                     .digest(header.getUrl().getBytes("UTF-8"));
 			// String url_base64 =

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -664,7 +664,6 @@ public class WARCIndexer {
 				throw new Exception( "Status code out of range: " + statusCodeInt );
 			// Get the other headers:
 			
-			solr.addField(SolrFields.HTTP_STATUS, Integer.toString(statusCodeInt));
 			for( Header h : httpHeaders ) {
 			  // Get the type from the server
 				if (h.getName().equalsIgnoreCase(HttpHeaders.CONTENT_TYPE)

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -656,6 +656,8 @@ public class WARCIndexer {
 			if( statusCodeInt < 0 || statusCodeInt > 1000 )
 				throw new Exception( "Status code out of range: " + statusCodeInt );
 			// Get the other headers:
+			
+			solr.addField(SolrFields.HTTP_STATUS, Integer.toString(statusCodeInt));
 			for( Header h : httpHeaders ) {
 				// Get the type from the server
 				if (h.getName().equalsIgnoreCase(HttpHeaders.CONTENT_TYPE)

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -113,7 +113,7 @@ public class WARCIndexerCommand {
 		options.addOption("o", "output", true,
 				"The directory to contain the output XML files");
 		options.addOption("s", "solr", true,
-				"The URL of the required Solr Instance");
+                "The URL of the Solr instance the document should be sent to");
 		options.addOption("t", "text", false,
 				"Include text in XML in output files");
 		options.addOption("r", "slash", false,
@@ -232,7 +232,13 @@ public class WARCIndexerCommand {
 		Config conf = ConfigFactory.load();
 		if (configFile != null) {
 			log.info("Loading config from log file: " + configFile);
-			conf = ConfigFactory.parseFile(new File(configFile));
+			File configFilePath = new File(configFile);
+			if (!configFilePath.exists()){
+			  log.error("Config file not found:"+configFile);
+	          System.exit( 0 );            			  
+			}
+			
+			conf = ConfigFactory.parseFile(configFilePath);
 			// ConfigPrinter.print(conf);
 			// conf.withOnlyPath("warc").root().render(ConfigRenderOptions.concise()));
 			log.info("Loaded warc config.");
@@ -300,6 +306,10 @@ public class WARCIndexerCommand {
                 ArchiveRecord rec = ir.next();
                 SolrRecord doc = new SolrRecord(inFile.getName(),
                                                 rec.getHeader());
+                log.debug("Processing record for url "
+                        + rec.getHeader().getUrl()
+                        + " from " + inFile.getName() + " @"
+                        + rec.getHeader().getOffset());
                 try {
                     doc = windex.extract(inFile.getName(), rec, isTextRequired);
                 } catch (Exception e) {
@@ -380,7 +390,7 @@ public class WARCIndexerCommand {
 	 */
 	private static void checkSubmission(SolrWebServer solr,
 			List<SolrInputDocument> docs, int limit, boolean force) {
-		if (docs.size() > 0 && docs.size() >= limit || force) {
+        if (docs.size() > 0 && (docs.size() >= limit || force)) {
 			try {
 				final long start = System.nanoTime();
 				if (log.isTraceEnabled() || debugMode) {

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
@@ -116,6 +116,10 @@ public interface SolrFields {
 	public static final String PUBLICATION_YEAR = "publication_year";
 	public static final String LAST_MODIFIED = "last_modified";
 	public static final String LAST_MODIFIED_YEAR = "last_modified_year";
+		
+	//Image Exif metadata
+	public static final String EXIF_VERSION = "exif_version";
+	public static final String EXIF_LOCATION = "exif_location";	 
 	
 	public static final String POSTCODE = "postcode";
 	public static final String POSTCODE_DISTRICT = "postcode_district";

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
@@ -36,6 +36,7 @@ public interface SolrFields {
 	public static final String SOLR_URL = "url";
 	public static final String SOURCE_FILE = "source_file";
 	public static final String SOURCE_FILE_OFFSET = "source_file_offset";
+	public static final String SOURCE_FILE_PATH = "source_file_path";
 	// Intended for building links-graphs. Normalised the same way as SOLR_LINKS
 	public static final String SOLR_URL_NORMALISED = "url_norm";
 	public static final String SOLR_URL_PATH = "url_path";

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
@@ -82,7 +82,6 @@ public interface SolrFields {
 	public static final String CONTENT_TYPE_DROID_B = "content_type_droid_b";	
 	public static final String CONTENT_TYPE_SERVED = "content_type_served";
 	public static final String CONTENT_TYPE_EXT = "content_type_ext";
-	public static final String HTTP_STATUS = "http_status";
 	public static final String SOLR_NORMALISED_CONTENT_TYPE = "content_type_norm";
 	public static final String CONTENT_FFB = "content_ffb"; /* The first four bytes */
 	public static final String CONTENT_FIRST_BYTES = "content_first_bytes";

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
@@ -79,9 +79,10 @@ public interface SolrFields {
 	public static final String FULL_CONTENT_TYPE = "content_type_full";
 	public static final String CONTENT_TYPE_TIKA = "content_type_tika";
 	public static final String CONTENT_TYPE_DROID = "content_type_droid";
-	public static final String CONTENT_TYPE_DROID_B = "content_type_droid_b";
+	public static final String CONTENT_TYPE_DROID_B = "content_type_droid_b";	
 	public static final String CONTENT_TYPE_SERVED = "content_type_served";
 	public static final String CONTENT_TYPE_EXT = "content_type_ext";
+	public static final String HTTP_STATUS = "http_status";
 	public static final String SOLR_NORMALISED_CONTENT_TYPE = "content_type_norm";
 	public static final String CONTENT_FFB = "content_ffb"; /* The first four bytes */
 	public static final String CONTENT_FIRST_BYTES = "content_first_bytes";

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
@@ -96,6 +96,10 @@ public interface SolrFields {
 	
 	public static final String SOLR_RECORD_TYPE = "record_type";
 	
+	//WARC header information
+	public static final String WARC_KEY_ID = "warc_key_id";
+	public static final String WARC_IP = "warc_ip";
+	
 	public static final String CONTENT_LENGTH = "content_length";
 	public static final String SOLR_TIMESTAMP = "timestamp";
 	public static final String SOLR_REFERRER_URI = "referrer_url";

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
@@ -65,6 +65,7 @@ public interface SolrFields {
 	public static final String SOLR_COLLECTION = "collection"; // Top-level collection
 	public static final String SOLR_COLLECTIONS = "collections"; // All collections.
 	
+	public static final String SOLR_LINKS_IMAGES = "links_images";
 	public static final String SOLR_LINKS = "links";
 	public static final String SOLR_LINKS_HOSTS = "links_hosts";
     public static final String SOLR_LINKS_HOSTS_SURTS = "links_hosts_surts";

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/TikaExtractor.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/TikaExtractor.java
@@ -327,7 +327,7 @@ mime_exclude = x-tar,x-gzip,bz,lz,compress,zip,javascript,css,octet-stream,image
 					metadata.get(Metadata.CONTENT_ENCODING));
 
 			// Parse out any embedded date that can act as a created/modified date.
-			// I was not able find a single example where both created and modified where defined and different. So just have a single field to both.
+			// I was not able find a single example where both created and modified where defined and different. I single field is sufficient.
 			String date = null;
 			if( metadata.get( Metadata.CREATION_DATE ) != null)
 				date = metadata.get( Metadata.CREATION_DATE );

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/TikaExtractor.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/TikaExtractor.java
@@ -327,6 +327,7 @@ mime_exclude = x-tar,x-gzip,bz,lz,compress,zip,javascript,css,octet-stream,image
 					metadata.get(Metadata.CONTENT_ENCODING));
 
 			// Parse out any embedded date that can act as a created/modified date.
+			// I was not able find a single example where both created and modified where defined and different. So just have a single field to both.
 			String date = null;
 			if( metadata.get( Metadata.CREATION_DATE ) != null)
 				date = metadata.get( Metadata.CREATION_DATE );

--- a/warc-indexer/src/main/resources/log4j-override.properties
+++ b/warc-indexer/src/main/resources/log4j-override.properties
@@ -20,3 +20,4 @@ log4j.logger.uk.gov.nationalarchives.droid=ERROR
 log4j.logger.org.apache=WARN
 log4j.logger.org.apache.solr=WARN
 log4j.logger.org.apache.solr.hadoop=WARN
+log4j.logger.org.apache.pdfbox=ERROR

--- a/warc-indexer/src/main/resources/reference.conf
+++ b/warc-indexer/src/main/resources/reference.conf
@@ -81,7 +81,8 @@
                     "normalise" : false,
                     "resources" : false,
                     "hosts" : true,
-                    "domains" : true
+                    "domains" : true,
+                    "images" : true
                 },
                 
                 # Restrict record types:

--- a/warc-indexer/src/main/resources/reference.conf
+++ b/warc-indexer/src/main/resources/reference.conf
@@ -65,11 +65,11 @@
                     # ARC name parsing
                     "arcname" : {
                         # Order is significant. Processing stops after first match
-                        "rules" : [
-                            { "pattern" :".*(job[0-9]+)-([0-9]{4})([0-9]{2})([0-9]{2})-([0-9]{2})([0-9]{2})([0-9]{2}).warc",
+                        "rules" : [                            
+                            # the field arc_full will be required in schema.xml. Stores the absolute path of the warc file when indexed.
+                            { "pattern" : "^.*$",
                                templates : {
-                                   "harvest_job" : "$1",
-                                   "harvest_year" : "$2"
+                                   "arc_full" : "$0",                            
                                }
                             }
                         ]

--- a/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
@@ -98,6 +98,7 @@
         <field name="sentiment_score" type="float" indexed="true" stored="true" multiValued="false"/>
         <field name="sentiment" type="string" indexed="true" docValues="true" multiValued="false"/>
         <field name="server" type="string" indexed="true" docValues="true" multiValued="true"/>
+        <field name="source_file_path" type="string" indexed="true" docValues="true" />
         <field name="source_file_offset" type="tlong" indexed="true" stored="true" />
         <field name="source_file" type="string" indexed="true" docValues="true" />
         <field name="status_code" type="int" indexed="true" stored="true" docValues="true" />

--- a/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
@@ -22,6 +22,9 @@
         <field name="_version_" type="long" indexed="true" docValues="true"/>
         <field name="_root_" type="string" indexed="true" docValues="true" />
         <field name="_text_" type="text_general" indexed="true" stored="false" multiValued="true"/>
+         
+         <!--Not defined in SolrFields. Schema only defintion -->
+        <field name="index_time" type="date" indexed="true" stored="false" docValues="true" default="NOW" /> 
 
         <!-- BL UKWA: additional -->
         <field name="access_terms" type="string" indexed="true" docValues="true" multiValued="true"/>

--- a/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
@@ -315,7 +315,10 @@
 
         <fieldType name="ignored" stored="false" indexed="false" docValues="false" multiValued="true" class="solr.StrField" />
         <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
+        <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate" docValues="false"/>
+        <!-- For Solr 6 use this instead: 
         <fieldType name="location" class="solr.LatLonPointSpatialField" docValues="true"/>
+         -->
 
         <fieldType name="text_ga" class="solr.TextField" positionIncrementGap="100">
                 <analyzer> 

--- a/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
@@ -122,6 +122,11 @@
         <field name="warc_ip" type="string" indexed="true" docValues="true" multiValued="false"/>
         <!--:BL UKWA -->
 
+
+        <!-- Custom field names can be defined from warcfile name.  Regexp-rules defined in the warc-indexer config file-->        
+        <!-- arc_full is required for solrwayback. Will only be used if defined in the config file--> 
+        <field name="arc_full" type="string" indexed="true" stored="true" multiValued="false"/> 
+
         <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"/>
         <dynamicField name="*_is" type="ints"    indexed="true"  stored="true"/>
         <dynamicField name="*_s"  type="string"  indexed="true"  stored="true" />

--- a/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
@@ -115,6 +115,8 @@
         <field name="wct_target_id" type="string" indexed="true" docValues="true" multiValued="false"/>
         <field name="wct_title" type="string" indexed="true" docValues="true"/>
         <field name="xml_root_ns" type="string" indexed="true" docValues="true" multiValued="false"/>
+        <field name="warc_key_id" type="string" indexed="true" docValues="true" multiValued="false"/>
+        <field name="warc_ip" type="string" indexed="true" docValues="true" multiValued="false"/>
         <!--:BL UKWA -->
 
         <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"/>

--- a/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
@@ -73,6 +73,7 @@
         <field name="last_modified" type="tdate" indexed="true" stored="true" docValues="true"/>
         <field name="last_modified_year" type="string" indexed="true" docValues="true"/>
         <field name="license_url" type="string" indexed="true" docValues="true" multiValued="true"/>
+        <field name="links_images" type="string" indexed="true" docValues="true" multiValued="true"/> 
         <field name="links_domains" type="string" indexed="true" docValues="true" multiValued="true"/>
         <field name="links_hosts" type="string" indexed="true" docValues="true" multiValued="true"/>
         <field name="links_hosts_surts" type="string" indexed="true" docValues="true" multiValued="true"/>

--- a/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
@@ -151,6 +151,10 @@
         <dynamicField name="attr_*" type="text_general" indexed="true" stored="true" multiValued="true"/>
         <dynamicField name="random_*" type="random" />
 
+        <!--:IMAGE EXIF-->
+        <field name="exif_location" type="location" indexed="true" stored="true" multiValued="false"/>          
+        <field name="exif_version" type="string" indexed="true" stored="true" multiValued="false"/> 
+        
         <!-- BL UKWA: additional -->
         <dynamicField name="ssdeep_hash_bs_*" type="string" indexed="true" stored="true" multiValued="false"/>
         <dynamicField name="ssdeep_hash_ngram_bs_*" type="literal_ngram" indexed="true" stored="true" multiValued="false"/>

--- a/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
@@ -42,8 +42,7 @@
         <field name="content_type_ext" type="string" indexed="true" docValues="true" multiValued="false"/>
         <field name="content_type_full" type="string" indexed="true" docValues="true" multiValued="false"/>
         <field name="content_type_norm" type="string" indexed="true" docValues="true" multiValued="false" default="other"/>
-        <field name="content_type_served" type="string" indexed="true" docValues="true" multiValued="false"/>
-        <field name="http_status" type="tint" indexed="true" docValues="true" multiValued="false"/>
+        <field name="content_type_served" type="string" indexed="true" docValues="true" multiValued="false"/>       
         <field name="content" type="text_general" indexed="false" stored="true" multiValued="true"/>
         <field name="content_type_tika" type="string" indexed="true" docValues="true" multiValued="false"/>
         <field name="content_type" type="string" indexed="true" docValues="true" multiValued="true"/>

--- a/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
@@ -43,6 +43,7 @@
         <field name="content_type_full" type="string" indexed="true" docValues="true" multiValued="false"/>
         <field name="content_type_norm" type="string" indexed="true" docValues="true" multiValued="false" default="other"/>
         <field name="content_type_served" type="string" indexed="true" docValues="true" multiValued="false"/>
+        <field name="http_status" type="tint" indexed="true" docValues="true" multiValued="false"/>
         <field name="content" type="text_general" indexed="false" stored="true" multiValued="true"/>
         <field name="content_type_tika" type="string" indexed="true" docValues="true" multiValued="false"/>
         <field name="content_type" type="string" indexed="true" docValues="true" multiValued="true"/>

--- a/warc-indexer/src/test/java/uk/bl/wa/analyser/payload/WARCPayloadAnalysersTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/analyser/payload/WARCPayloadAnalysersTest.java
@@ -38,7 +38,7 @@ public class WARCPayloadAnalysersTest extends TestCase {
     public void testConfig() {
         ARCNameAnalyser ana = getAnalyser();
         assertEquals("The expected number of rules should be created",
-                     7, ana.getRules().size());
+                     12, ana.getRules().size());
         assertEquals("The number of templates for the first rule should be correct",
                      2, ana.getRules().get(0).templates.size());
     }

--- a/warc-indexer/src/test/resources/arcnameanalyser.conf
+++ b/warc-indexer/src/test/resources/arcnameanalyser.conf
@@ -184,7 +184,8 @@
                 "linked" : {
                     "resources" : false,
                     "hosts" : true,
-                    "domains" : true
+                    "domains" : true,
+                    "images" : true
                 },
                 
                 # Restrict record types:

--- a/warc-indexer/src/test/resources/links_extract.conf
+++ b/warc-indexer/src/test/resources/links_extract.conf
@@ -49,7 +49,8 @@
                 "linked" : {
                     "resources" : true,
                     "hosts" : true,
-                    "domains" : true
+                    "domains" : true,
+                    "images" : true
                 },
                 
                 # Restrict record types:


### PR DESCRIPTION
Hi Andy.
This is first off 2 pull requests from us. This one has a few new fields and minor changes. Read the changes about the links field. The next pull request will come in 2 weeks and will be enchancments to revisits records.
/Thomas Egense

New solr fields:
index_time . When the record was indexed. This is useful for researchers to define a corpus that does not change when more is indexed.
links_images. All images on an html page. 
warc_key_id  (from warc header)
warc_ip (from warc header)
arc_full (Only if defined in config.conf). Stores the absolute path of the warc. (for solrwayback)
exif_location (for images, only if enabled in config.con)
exif_version (for images, only if enabled in config.con)
links (already defined by you, but I have normalized the links to match them the same document. Will this be a problem for you?)


Other changes:
index image height/size if configured (very fast implementation, almost no overhead)
WarcIndexer log (supress PDF errors)
Minor unittests changes.