### PR TITLE
Move annotations call from CLI to config file (issue #113)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 * new solr field: index_time
 * Two new fields from warc-header: warc_key_id, warc_ip
 * More field values extracted for revisit records.
+* Usage of annotations from config file [#113](https://github.com/ukwa/webarchive-discovery/issues/113)
 
 2.1.0
 -----

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -224,6 +224,20 @@ public class WARCIndexer {
 		this.wpa = new WARCPayloadAnalysers(conf);
 		this.txa = new TextAnalysers(conf);
 
+		// Set up annotator
+		if (conf.hasPath("warc.index.extract.content.annotations.enabled") && conf.getBoolean("warc.index.extract.content.annotations.enabled")) {
+			String annotationsFile = conf.getString("warc.index.extract.content.annotations.file");
+			String openAccessSurtsFile = conf.getString("warc.index.extract.content.annotations.surt_prefix_file");
+			try {
+				Annotations ann = Annotations.fromJsonFile(annotationsFile);
+				SurtPrefixSet oaSurts = Annotator.loadSurtPrefix(openAccessSurtsFile);
+				this.ant = new Annotator(ann, oaSurts);
+			} catch (IOException e) {
+				log.error("Failed to load annotations files.");
+				throw new RuntimeException("Annotations failed with IOException when loading files " + annotationsFile + ", " + openAccessSurtsFile);
+			}
+		}
+
 		// We want stats for the 20 resource types that we spend the most time processing
 		Instrument.createSortedStat("WARCIndexer#content_types", Instrument.SORT.time, 20);
 

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -59,11 +59,14 @@ import org.apache.solr.common.SolrInputDocument;
 import org.archive.io.ArchiveReader;
 import org.archive.io.ArchiveReaderFactory;
 import org.archive.io.ArchiveRecord;
+import org.archive.util.SurtPrefixSet;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 
+import uk.bl.wa.annotation.Annotations;
+import uk.bl.wa.annotation.Annotator;
 import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
 import uk.bl.wa.solr.SolrWebServer;
@@ -104,6 +107,7 @@ public class WARCIndexerCommand {
 		boolean isTextRequired = false;
 		boolean slashPages = false;
 		int batchSize = -1; // No explicit batch size (defaults to 1 if not stated in the conf-file)
+		String annotationsFile = null;
         boolean disableCommit;
 		
 		Options options = new Options();
@@ -117,6 +121,8 @@ public class WARCIndexerCommand {
 				"Include text in XML in output files");
 		options.addOption("r", "slash", false,
 				"Only process slash (root) pages.");
+		options.addOption("a", "annotations", true,
+				"A JSON file containing the annotations to apply during indexing.");
 		options.addOption("b", "batch", true, "Batch size for submissions.");
 		options.addOption("c", "config", true, "Configuration to use.");
 		options.addOption("d", "disable_commit", false,
@@ -190,11 +196,16 @@ public class WARCIndexerCommand {
 		   		System.exit( 0 );
 		   	}
 
+			// Pick up any annotations specified:
+			if (line.hasOption("a")) {
+				annotationsFile = line.getOptionValue("a");
+			}
+
             // Check for commit disabling
             disableCommit = line.hasOption("d");
 
 			parseWarcFiles(configFile, outputDir, gzip, solrUrl, cli_args,
-                           isTextRequired, slashPages, batchSize, disableCommit);
+                           isTextRequired, slashPages, batchSize, annotationsFile, disableCommit);
 		
 		} catch (org.apache.commons.cli.ParseException e) {
 			log.error("Parse exception when processing command line arguments: "+e);
@@ -214,7 +225,8 @@ public class WARCIndexerCommand {
 	 */
 	public static void parseWarcFiles(String configFile, String outputDir, boolean gzip,
 			String solrUrl, String[] args, boolean isTextRequired,
-			boolean slashPages, int batchSize, boolean disableCommit)
+			boolean slashPages, int batchSize, String annotationsFile,
+            boolean disableCommit)
 			throws NoSuchAlgorithmException,
 			TransformerFactoryConfigurationError, TransformerException,
 			IOException {
@@ -255,6 +267,14 @@ public class WARCIndexerCommand {
 
 		// Also pass config down:
 		WARCIndexer windex = new WARCIndexer(conf);
+
+		// Add in annotations, if set:
+		if (annotationsFile != null) {
+			Annotations ann = Annotations.fromJsonFile(annotationsFile);
+            SurtPrefixSet oaSurts = Annotator
+                    .loadSurtPrefix("openAccessSurts.txt");
+            windex.setAnnotations(ann, oaSurts);
+		}
 		
 
 		// To be indexed:

--- a/warc-indexer/src/main/resources/reference.conf
+++ b/warc-indexer/src/main/resources/reference.conf
@@ -74,6 +74,12 @@
                             }
                         ]
                     }
+                    # Annotations file
+                    "annotations" : {
+                        "enabled" : false,
+                        "file" : "/path/to/annotations.json",
+                        "surt_prefix_file" : "/path/to/openAccessSurts.txt"
+                    }
                 },
                 
                 # Which linked entities to extract:


### PR DESCRIPTION
Instead of giving the annotations file in the command line, there is now in the config file a setting to enable the annotations mechanism and define the annotations file path and the openAccessSurts file.