### PR TITLE
URL-normalisation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 
 **NOTE** The changes to the schema mean this version is not compatible with 2.1.0 indexes. We've also moved to Java 7.
 
+* Refactored and extended URL-normalisation [#115](https://github.com/ukwa/webarchive-discovery/issues/115) and [#119](https://github.com/ukwa/webarchive-discovery/issues/119)
 * Updated performance instrumentation, with break down of time used on common file types
 * Switched to docValues for most fields [#51](https://github.com/ukwa/webarchive-discovery/issues/51)
 * Switched to separate fields for the source file and offset references, and dropped the _s suffix.

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
@@ -60,7 +60,8 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 	private boolean extractLinks;
 	private boolean extractElementsUsed;
     private boolean extractImageLinks;
-	
+    private boolean normaliseLinks;
+
 	public HTMLAnalyser( Config conf ) {
 	    this.extractLinks = conf.getBoolean( "warc.index.extract.linked.resources" );
 		log.info("HTML - Extract resource links " + this.extractLinks);
@@ -72,6 +73,10 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 		log.info("HTML - Extract elements used " + this.extractElementsUsed);
         this.extractImageLinks = conf.getBoolean( "warc.index.extract.linked.images" );
 	    log.info("HTML - Extract image links " + this.extractElementsUsed);
+		normaliseLinks = conf.hasPath(uk.bl.wa.parsers.HtmlFeatureParser.CONF_LINKS_NORMALISE) ?
+               conf.getBoolean(uk.bl.wa.parsers.HtmlFeatureParser.CONF_LINKS_NORMALISE) :
+				uk.bl.wa.parsers.HtmlFeatureParser.DEFAULT_LINKS_NORMALISE;
+
         hfp = new HtmlFeatureParser(conf);
 	}
 	/**
@@ -109,7 +114,7 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
           String[] imageLinks = metadata.getValues( HtmlFeatureParser.IMAGE_LINKS );
           if (imageLinks != null){            
             for( String link : imageLinks ) { 
-              String urlNorm  = Normalisation.canonicaliseURL(link);
+              String urlNorm  = normaliseLinks ? Normalisation.canonicaliseURL(link) : link;
               solr.addField( SolrFields.SOLR_LINKS_IMAGES, urlNorm);
             }
           }                
@@ -134,7 +139,7 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 				}
 				// Also store actual resource-level links:
 				if( this.extractLinks ){
-				    String urlNorm  = Normalisation.canonicaliseURL(link);
+					String urlNorm  = normaliseLinks ? Normalisation.canonicaliseURL(link) : link;
 					solr.addField( SolrFields.SOLR_LINKS, urlNorm );
 				}
 			}

--- a/warc-indexer/src/main/java/uk/bl/wa/annotation/AnnotationsFromAct.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/annotation/AnnotationsFromAct.java
@@ -43,7 +43,6 @@ import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.solr.common.util.Base64;
-import org.archive.wayback.util.url.AggressiveUrlCanonicalizer;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.JsonParser;
@@ -76,8 +75,6 @@ public class AnnotationsFromAct {
 
 	private static Log LOG = LogFactory.getLog( AnnotationsFromAct.class );
 	
-	private AggressiveUrlCanonicalizer canon = new AggressiveUrlCanonicalizer();
-
 	private String cookie;
 	private String csrf;
 

--- a/warc-indexer/src/main/java/uk/bl/wa/annotation/Annotator.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/annotation/Annotator.java
@@ -58,7 +58,6 @@ import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
 import org.archive.url.UsableURIFactory;
 import org.archive.util.SurtPrefixSet;
-import org.archive.wayback.util.url.AggressiveUrlCanonicalizer;
 import org.jdom.JDOMException;
 
 import uk.bl.wa.indexer.WARCIndexer;
@@ -79,8 +78,6 @@ public class Annotator {
 
     private SurtPrefixSet openAccessSurts = null;
 
-	private AggressiveUrlCanonicalizer canon = new AggressiveUrlCanonicalizer();
-	
 
 	/**
 	 * Factory method to pull annotations from ACT.

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -73,7 +73,6 @@ import org.archive.util.SurtPrefixSet;
 import org.archive.wayback.accesscontrol.staticmap.StaticMapExclusionFilterFactory;
 import org.archive.wayback.core.CaptureSearchResult;
 import org.archive.wayback.resourceindex.filters.ExclusionFilter;
-import org.archive.wayback.util.url.AggressiveUrlCanonicalizer;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
@@ -94,6 +93,7 @@ import uk.bl.wa.solr.SolrRecord;
 import uk.bl.wa.solr.SolrWebServer;
 import uk.bl.wa.util.HashedCachedInputStream;
 import uk.bl.wa.util.Instrument;
+import uk.bl.wa.util.Normalisation;
 
 /**
  * 
@@ -113,7 +113,6 @@ public class WARCIndexer {
 	private List<String> record_type_includes;
 
 	private MessageDigest md5 = null;
-	private AggressiveUrlCanonicalizer canon = new AggressiveUrlCanonicalizer();
 
 	/** */
 	private boolean extractText;
@@ -140,7 +139,6 @@ public class WARCIndexer {
 
     // Paired with HtmlFeatureParsers links-extractor
     private final boolean addNormalisedURL;
-    private final AggressiveUrlCanonicalizer urlNormaliser = new AggressiveUrlCanonicalizer();
 
 	// Also canonicalise the HOST field (e.g. drop "www.")
 	public static final boolean CANONICALISE_HOST = true;
@@ -344,10 +342,7 @@ public class WARCIndexer {
 			String url_md5hex = Base64.encodeBase64String(url_md5digest);
             solr.setField(SolrFields.SOLR_URL, header.getUrl());
             if (addNormalisedURL) {
-            	// TODO: This is very messy. All the URL-normalising should be moved to a helper class
-				String normURL = urlNormaliser.canonicalize(
-						targetUrl.startsWith("https://") ? "http://" + targetUrl.substring(8) : targetUrl);
-                solr.setField( SolrFields.SOLR_URL_NORMALISED, urlNormaliser.canonicalize(normURL) );
+                solr.setField( SolrFields.SOLR_URL_NORMALISED, Normalisation.canonicaliseURL(targetUrl) );
             }
 
 			// Get the length, but beware, this value also includes the HTTP headers (i.e. it is the payload_length):
@@ -632,7 +627,7 @@ public class WARCIndexer {
         // and the public suffix:
         String host = url.getHost();
         if (CANONICALISE_HOST)
-            host = canon.urlStringToKey(host).replace("/", "");
+            host = Normalisation.canonicaliseHost(host);
         solr.setField(SolrFields.SOLR_HOST, host);
 
         // Add the SURT host
@@ -658,10 +653,6 @@ public class WARCIndexer {
 
     }
 
-	/**
-	 * @param firstDate
-	 * @return
-	 */
 	private synchronized String getYearFromDate(Date date) {
 		calendar.setTime(date);
 		return Integer.toString(calendar.get(Calendar.YEAR));
@@ -722,11 +713,6 @@ public class WARCIndexer {
 		return null;
 	}
 
-	/**
-	 * 
-	 * @param fullUrl
-	 * @return
-	 */
 	protected static String parseExtension(String path) {
 		if (path != null && path.indexOf(".") != -1) {
 			String ext = path.substring(path.lastIndexOf("."));

--- a/warc-indexer/src/main/java/uk/bl/wa/parsers/HtmlFeatureParser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/parsers/HtmlFeatureParser.java
@@ -43,7 +43,6 @@ import org.apache.tika.metadata.Property;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
-import org.archive.wayback.util.url.AggressiveUrlCanonicalizer;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -53,6 +52,7 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import uk.bl.wa.util.Instrument;
+import uk.bl.wa.util.Normalisation;
 
 public class HtmlFeatureParser extends AbstractParser {
 
@@ -276,9 +276,8 @@ public class HtmlFeatureParser extends AbstractParser {
      * @return the link in normalised form or the unchanged link if normalisation has not been enabled.
      */
     public String normaliseLink(String link) {
-        return normaliseLinks ? linkNormaliser.canonicalize(link) : link;
+        return normaliseLinks ? Normalisation.canonicaliseURL(link) : link;
     }
-    private final AggressiveUrlCanonicalizer linkNormaliser = new AggressiveUrlCanonicalizer();
 
     public static Metadata extractMetadata( InputStream in, String url ) {
 		HtmlFeatureParser hfp = new HtmlFeatureParser();

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/TikaExtractor.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/TikaExtractor.java
@@ -386,18 +386,24 @@ mime_exclude = x-tar,x-gzip,bz,lz,compress,zip,javascript,css,octet-stream,image
 			  String exif_latitude = metadata.get("GPS Latitude");
 	          String exif_longitude = metadata.get("GPS Longitude");	        
 	          	          
-	          if (exif_latitude != null && exif_longitude != null){
-	            try{
-	              double latitude = DMS2DG(exif_latitude);
-	              double longitude = DMS2DG( exif_longitude);                 
-                  if (latitude != 0d && longitude != 0d){ // Sometimes they are defined but both 0
-                     solr.addField(SolrFields.EXIF_LOCATION, latitude+","+longitude);
-                  }
-	            }
-	            catch(Exception e){ //Just ignore. No GPS data added to solr
-	              log.error("error parsing exif gps data. latitude:"+exif_latitude +" longitude:"+exif_longitude);
-	            }	            	          
-	          }	          	            
+				if (exif_latitude != null && exif_longitude != null){
+					double latitude = DMS2DG(exif_latitude);
+					double longitude = DMS2DG( exif_longitude);
+
+					try {
+						if (latitude != 0d && longitude != 0d){ // Sometimes they are defined but both 0
+							if (latitude <= 90 && latitude >= -90 && longitude <= 180 && longitude >= -180){
+								solr.addField(SolrFields.EXIF_LOCATION, latitude+","+longitude);
+							}
+							else{
+								log.error("invalid gsp exif information:"+exif_latitude +","+exif_longitude);
+							}
+
+						}
+					} catch(Exception e){ //Just ignore. No GPS data added to solr
+						log.error("error parsing exif gps data. latitude:"+exif_latitude +" longitude:"+exif_longitude);
+					}
+				}
 			}
 			//End image exif metadata
 			

--- a/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
@@ -1,0 +1,173 @@
+package uk.bl.wa.util;
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ */
+
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
+import org.archive.wayback.util.url.AggressiveUrlCanonicalizer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+
+/**
+ * String- and URL-normalisation helper class.
+ */
+public class Normalisation {
+    private static Log log = LogFactory.getLog(Normalisation.class);
+
+    private static Charset UTF8_CHARSET = Charset.forName("UTF-8");
+    private static AggressiveUrlCanonicalizer canon = new AggressiveUrlCanonicalizer();
+
+    public static String canonicaliseHost(String host) throws URIException {
+        return canon.urlStringToKey(host).replace("/", "");
+    }
+
+    /**
+     * The canonicalisation of URLs is intended for
+     * @param url
+     * @return
+     */
+    public static String canonicaliseURL(String url, boolean produceValidURL) {
+        // Basic normalisation, as shared with Heritrix, Wayback et al
+        url = canon.canonicalize(url);
+
+        // Protocol: https → http
+        url = url.startsWith("https://") ? "http://" + url.substring(8) : url;
+
+        // Trailing slashes: http://example.com/foo/ → http://example.com/foo
+        while (!produceValidURL && url.endsWith("/")) { // Trailing slash affects the URL semantics
+            url = url.substring(0, url.length() - 1);
+        }
+
+        // Hex escapes, including faulty hex escape handling:
+        // http://example.com/all%2A rosé 10%.html → http://example.com/all*%20rosé%2010%25.html or
+        // http://example.com/all%2A rosé 10%.html → http://example.com/all*%20ros%C3%A9%2010%25.html if produceValidURL
+        url = escapeUTF8(fixEscapeErrorsAndUnescapeHighOrderUTF8(url), produceValidURL, !produceValidURL);
+
+        return url;
+    }
+
+    // Normalisation to UTF-8 form
+    private static byte[] fixEscapeErrorsAndUnescapeHighOrderUTF8(final String url) {
+        ByteArrayOutputStream sb = new ByteArrayOutputStream(url.length()*2);
+        final byte[] utf8 = url.getBytes(UTF8_CHARSET);
+        int i = 0;
+        while (i < utf8.length) {
+            int c = utf8[i];
+            if (c == '%') {
+                if (i < utf8.length-2 && isHex(utf8[i+1]) && isHex(utf8[i+2])) {
+                    int u = Integer.parseInt("" + (char)utf8[i+1] + (char)utf8[i+2], 16);
+                    if ((0b10000000 & u) == 0) { // ASCII, so don't touch!
+                        sb.write('%'); sb.write(utf8[i+1]); sb.write(utf8[i+2]);
+                    } else { // UTF-8, so write raw byte
+                        sb.write(0xFF & u);
+                    }
+                    i += 3;
+                } else { // Faulty, so fix by escaping percent
+                    sb.write('%'); sb.write('2'); sb.write('5');
+                    i++;
+                }
+                // https://en.wikipedia.org/wiki/UTF-8
+            } else { // Not part of escape, just pass the byte
+                sb.write(0xff & utf8[i++]);
+            }
+        }
+        return sb.toByteArray();
+    }
+
+    // Requires valid %-escapes (as produced by fixEscapeErrorsAndUnescapeHighOrderUTF8) and UTF-8 bytes
+    private static String escapeUTF8(final byte[] utf8, boolean escapeHighOrder, boolean normaliseLowOrder) {
+        ByteArrayOutputStream sb = new ByteArrayOutputStream(utf8.length*2);
+        int i = 0;
+        while (i < utf8.length) {
+            int c = utf8[i];
+            if (c == '%') {
+                int codePoint = Integer.parseInt("" + (char) utf8[i + 1] + (char) utf8[i + 2], 16);
+                if (mustEscape(codePoint) || !normaliseLowOrder) { // Pass on unmodified
+                    hexEscape(codePoint, sb);
+                } else { // Normalise to ASCII
+                    sb.write(0xFF & codePoint);
+                }
+                i += 2;
+            } else if ((0b10000000 & c) == 0) { // ASCII
+                if (mustEscape(c)) {
+                    hexEscape(c, sb);
+                } else {
+                    sb.write(0xFF & c);
+                }
+            } else if ((0b11100000 & c) == 0b11000000) { // 2 byte UTF-8
+                if (escapeHighOrder) {
+                    hexEscape(0xff & utf8[i++], sb);
+                    hexEscape(0xff & utf8[i], sb);
+                } else {
+                    sb.write(utf8[i++]);
+                    sb.write(utf8[i]);
+                }
+            } else if ((0b11110000 & utf8[i]) == 0b11100000) { // 3 byte UTF-8
+                hexEscape(0xff & utf8[i++], sb);
+                hexEscape(0xff & utf8[i++], sb);
+                hexEscape(0xff & utf8[i], sb);
+            } else if ((0b11111000 & utf8[i]) == 0b11110000) { // 4 byte UTF-8
+                hexEscape(0xff & utf8[i++], sb);
+                hexEscape(0xff & utf8[i++], sb);
+                hexEscape(0xff & utf8[i++], sb);
+                hexEscape(0xff & utf8[i], sb);
+            } else {
+                // TODO: Make a hex-dump of the first x bytes for a better error message
+                throw new IllegalArgumentException("The input byte-array did not translate to supported UTF-8");
+            }
+            i++;
+        }
+        try {
+            return sb.toString("utf-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("Internal error: UTF-8 must be supported by the JVM", e);
+        }
+
+    }
+
+    private static void hexEscape(int codePoint, ByteArrayOutputStream sb) {
+        sb.write('%');
+        sb.write(HEX[codePoint >> 4]);
+        sb.write(HEX[codePoint & 0xF]);
+    }
+    private final static byte[] HEX = "0123456789abcdef".getBytes(UTF8_CHARSET);
+
+    private static boolean mustEscape(int codePoint) {
+        return codePoint == ' ';
+    }
+
+
+    // Hex escapes:
+    // http://example.com/all%2A rosé 10%.html → http://example.com/all*%20rosé%2010%25.html or
+    // http://example.com/all%2A rosé 10%.html → http://example.com/all*%20ros%C3%A9%2010%25.html if produceValidURL
+    //
+    // - Space is escaped to %20
+    // - High-order UTF-8 characters are kept as-is, unless produceValidURL is true in which case they are escaped
+    // - Faulty hex escapes (%.html) are handled by escaping the percent (%25.html)
+    //
+    // If a canonicalised URL is to be used for requests to an external web-service, it must either be constructed
+    // with produceValidURL or the calling client must handle escaping. e.g. curl's --data-urlencode.
+    //
+    // Note: The normalisation is less strong if produceValidURL is true, e.g. %2A and * are treated as different
+    private static boolean isHex(byte b) {
+        return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F');
+    }
+
+
+}

--- a/warc-indexer/src/test/java/uk/bl/wa/extract/LinkExtractorTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/extract/LinkExtractorTest.java
@@ -24,7 +24,11 @@ package uk.bl.wa.extract;
 
 import static org.junit.Assert.assertEquals;
 
+import org.apache.commons.httpclient.URIException;
+import org.archive.url.UsableURI;
+import org.archive.url.UsableURIFactory;
 import org.junit.Test;
+import uk.bl.wa.util.Normalisation;
 
 public class LinkExtractorTest {
 
@@ -50,6 +54,29 @@ public class LinkExtractorTest {
         System.err.println("domain " + domain + " from " + host);
         assertEquals(expectedResult, domain);
 
+    }
+
+    // What is a domain? Answer: It depends. Not just on country-level (the uk-system), but also on individual services.
+    @Test
+    public void testExtractDomainFromFullURL() throws URIException {
+        final String[][] TESTS = new String[][]{
+                // url, host, domain
+                {"http://fourth.whatever.example.com/",    "fourth.whatever.example.com",    "example.com"},
+                {"http://fourth.whatever.googleapis.com/", "fourth.whatever.googleapis.com", "whatever.googleapis.com"},
+                {"http://fourth.whatever.cloudfront.net",  "fourth.whatever.cloudfront.net", "whatever.cloudfront.net"},
+                {"http://fourth.whatever.blogspot.dk/",    "fourth.whatever.blogspot.dk",    "whatever.blogspot.dk"}
+        };
+
+        for (String[] test: TESTS) {
+            UsableURI url = UsableURIFactory.getInstance(test[0]);
+
+            String host = url.getHost();
+            String canonHost = Normalisation.canonicaliseHost(host);
+            assertEquals("The URL '" + test[0] + "' should have the correct host extracted", test[1], canonHost);
+            
+            final String domain = LinkExtractor.extractPrivateSuffixFromHost(canonHost);
+            assertEquals("The URL '" + test[0] + "' should have the correct domain extracted", test[2], domain);
+        }
     }
 
 }

--- a/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
@@ -23,14 +23,58 @@ public class NormalisationTest {
     @Test
     public void testURLNormalisation() {
         final String[][] TESTS = new String[][]{
-                {"http://example.com", "http://example.com"},
-                {"http://example.com/", "http://example.com"},
-                {"https://example.com", "http://example.com"},
-                {"https://example.com", "http://example.com"}
+                // input, ambiguous, unambiguous
+                {"http://example.com",  "http://example.com/", "http://example.com/"},
+                {"http://example.com/", "http://example.com/", "http://example.com/"},
+                {"https://example.com", "http://example.com/", "http://example.com/"},
+                {"https://example.com", "http://example.com/", "http://example.com/"},
+                {"/foo",                "/foo",                "/foo"},
+                {"/foo/",               "/foo",                "/foo"},
+                {"/%2A",                "/%2a",                "/*"},
+                {"/%2a",                "/%2a",                "/*"},
+                {"/%2a*",               "/%2a*",                "/**"},
+                {"/æblegrød",           "/æblegrød",           "/æblegrød"},
+                {"%C3%A6blegr%C3%B8d",  "æblegrød",            "æblegrød"},
+                {"/æblegrød og øl",     "/æblegrød%20og%20øl", "/æblegrød%20og%20øl"},
+                {"Red, Rosé 14%",       "red,%20rosé%2014%25", "red,%20rosé%2014%25"},
+                {"Red%2C%20Ros%C3%A9 14%25", "red%2c%20rosé%2014%25",  "red,%20rosé%2014%25"}
         };
 
         for (String[] test: TESTS) {
-            assertEquals("The input '" + test[0] + "' should be normalised as expected",
+            assertEquals("The input '" + test[0] + "' should be normalised ambiguously as expected",
+                         test[1], Normalisation.canonicaliseURL(test[0], true, false));
+            assertEquals("The input '" + test[0] + "' should be normalised unambiguously as expected",
+                         test[2], Normalisation.canonicaliseURL(test[0], true, true));
+        }
+    }
+
+    @Test
+    public void testFaultyHighOrderNormalisation() {
+        final String[][] TESTS = new String[][]{
+                {"Red, Rosé 14%",            "red,%20ros%c3%a9%2014%25", "red,%20rosé%2014%25"},
+                {"red,%20ros%c3%a9%2014%25", "red,%20ros%c3%a9%2014%25", "red,%20rosé%2014%25"}
+        };
+
+        for (String[] test: TESTS) {
+            assertEquals("The input '" + test[0] + "' should be normalised with high-order escaping as expected",
+                         test[1], Normalisation.canonicaliseURL(test[0], false, true));
+            assertEquals("The input '" + test[0] + "' should be normalised without high-order escaping as expected",
+                         test[2], Normalisation.canonicaliseURL(test[0], true, true));
+        }
+    }
+
+    @Test
+    public void testFaultyHARDURLNormalisation() {
+        final String[][] TESTS = new String[][]{
+                {"http://example.com/%",         "http://example.com/%25"},
+                {"http://example.com/%%25",      "http://example.com/%25%25"},
+                {"http://example.com/10% proof", "http://example.com/10%25%20proof"},
+                {"http://example.com/%a%2A",     "http://example.com/%25a*"},
+                {"http://example.com/%g1%2A",    "http://example.com/%25g1*"},
+        };
+
+        for (String[] test: TESTS) {
+            assertEquals("The input '" + test[0] + "' should be normalised and error-corrected as expected",
                          test[1], Normalisation.canonicaliseURL(test[0]));
         }
     }

--- a/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
@@ -1,0 +1,37 @@
+package uk.bl.wa.util;
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ */
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class NormalisationTest {
+
+    @Test
+    public void testURLNormalisation() {
+        final String[][] TESTS = new String[][]{
+                {"http://example.com", "http://example.com"},
+                {"http://example.com/", "http://example.com"},
+                {"https://example.com", "http://example.com"},
+                {"https://example.com", "http://example.com"}
+        };
+
+        for (String[] test: TESTS) {
+            assertEquals("The input '" + test[0] + "' should be normalised as expected",
+                         test[1], Normalisation.canonicaliseURL(test[0]));
+        }
+    }
+}


### PR DESCRIPTION
Extraction of URL-normalisation to a single class and implementation of #115 and #119, so that `links` and `links_images` are now normalised unambiguously to `url_norm`. This should lift the quality of link matching.