### PR TITLE
Url hardening

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
@@ -153,8 +153,8 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
 						try {
 							cHost = Normalisation.canonicaliseHost(host);
 						} catch (URIException e) {
-							log.error("Failed to canonicalise host: " + host
-									+ ": " + e);
+							log.error("Failed to canonicalise host: '" + host
+									+ "': " + e);
 							cHost = host;
 						}
 					}

--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/WARCPayloadAnalysers.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/WARCPayloadAnalysers.java
@@ -44,6 +44,7 @@ import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
 import uk.bl.wa.solr.TikaExtractor;
 import uk.bl.wa.util.Instrument;
+import uk.bl.wa.util.Normalisation;
 import uk.gov.nationalarchives.droid.command.action.CommandExecutionException;
 
 
@@ -160,7 +161,7 @@ public class WARCPayloadAnalysers {
 				// Pass the URL in so DROID can fall back on that:
 				Metadata metadata = new Metadata();
 				if( passUriToFormatTools ) {
-					UsableURI uuri = UsableURIFactory.getInstance( header.getUrl() );
+					UsableURI uuri = UsableURIFactory.getInstance(Normalisation.fixURLErrors(header.getUrl()) );
 					// Droid seems unhappy about spaces in filenames, so hack to avoid:
 					String cleanUrl = uuri.getName().replace( " ", "+" );
 					metadata.set( Metadata.RESOURCE_NAME_KEY, cleanUrl );

--- a/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
@@ -46,7 +46,7 @@ public class Normalisation {
     private static AggressiveUrlCanonicalizer canon = new AggressiveUrlCanonicalizer();
 
     public static String canonicaliseHost(String host) throws URIException {
-        return canon.urlStringToKey(host).replace("/", "");
+        return canon.urlStringToKey(host.trim()).replace("/", "");
     }
 
     /**

--- a/warc-indexer/src/test/java/uk/bl/wa/parsers/HtmlFeatureParserTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/parsers/HtmlFeatureParserTest.java
@@ -87,14 +87,14 @@ public class HtmlFeatureParserTest {
         final String[][] TESTS = new String[][] { // Expected, input
 //                {"http://example.org", "http://www.example.org"},
                 {"http://example.org/foo", "http://www.example.org/foo"},
-                {"http://example.org", "http://example.org"},
-                {"http://example.org", "http://example.org?"},
+                {"http://example.org/", "http://example.org"},
+                {"http://example.org/", "http://example.org?"},
                 //{"http://example.org", "https://example.org?"},
-                {"http://example.org", "http://user@example.org"},
+                {"http://example.org/", "http://user@example.org"},
                 {"http://example.org/foo", "http://user@www.example.org/foo"},
 //                {"http://example.org", "http://user@www.example.org"},
-                {"http://example.org", "http://eXample.org"},
-                {"http://example.org", "http://example.ORG"},
+                {"http://example.org/", "http://eXample.org"},
+                {"http://example.org/", "http://example.ORG"},
 //                {"http://example.org", "http://example.org/"},
 //                {"http://example.org", "http://example.org/index.html"}
         };

--- a/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
@@ -23,6 +23,8 @@ package uk.bl.wa.util;
  */
 
 import static org.junit.Assert.assertEquals;
+
+import org.apache.commons.httpclient.URIException;
 import org.junit.Test;
 
 public class NormalisationTest {
@@ -114,6 +116,23 @@ public class NormalisationTest {
         for (String[] test: TESTS) {
             assertEquals("The input '" + test[0] + "' should be normalised and error-corrected as expected",
                          test[1], Normalisation.canonicaliseURL(test[0]));
+        }
+    }
+
+    @Test
+    public void testCanonicaliseHost() throws URIException {
+        final String[][] TESTS = new String[][]{
+                {"http://example.com/",  "example.com"},
+                {"http://example.com",   "example.com"},
+                {"http://example.com ",  "example.com"},
+
+                {"https://example.com/", "example.com"},
+                {"https://example.com",  "example.com"},
+                {"https://example.com ", "example.com"},
+        };
+        for (String[] test: TESTS) {
+            assertEquals("The input '" + test[0] + "' should be reduced to the expected host",
+                         test[1], Normalisation.canonicaliseHost(test[0]));
         }
     }
 }

--- a/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
@@ -1,18 +1,25 @@
 package uk.bl.wa.util;
+
 /*
+ * #%L
+ * warc-indexer
+ * %%
+ * Copyright (C) 2013 - 2017 The UK Web Archive
+ * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
  */
 
 import static org.junit.Assert.assertEquals;
@@ -60,6 +67,37 @@ public class NormalisationTest {
                          test[1], Normalisation.canonicaliseURL(test[0], false, true));
             assertEquals("The input '" + test[0] + "' should be normalised without high-order escaping as expected",
                          test[2], Normalisation.canonicaliseURL(test[0], true, true));
+        }
+    }
+
+    @Test
+    public void testNonUTF8Escapes() {
+        final String[][] TESTS = new String[][]{
+                {"http://example.com/%C3%86blegr%C3%B8d", "http://example.com/Æblegrød"},     // UTF-8 escapes
+                {"http://example.com/%C3%86blegr%C3",     "http://example.com/Æblegr%c3"},    // Half UTF-8 2-byte escape
+                {"http://example.com/Æblegrød",           "http://example.com/æblegrød"},     // Direct unicode
+                {"http://example.com/%C6blegr%F8d",       "http://example.com/%c6blegr%f8d"}, // ISO-8859-1
+        };
+
+        for (String[] test: TESTS) {
+            assertEquals("The input '" + test[0] + "' should be normalised as expected",
+                         test[1], Normalisation.canonicaliseURL(test[0]));
+        }
+    }
+
+    @Test
+    public void testEscapeFix() {
+        final String[][] TESTS = new String[][]{
+                {"http://example.com/%",         "http://example.com/%25"},
+                {"http://example.com/%%25",      "http://example.com/%25%25"},
+                {"http://example.com/10% proof", "http://example.com/10%25%20proof"},
+                {"http://example.com/%a%2A",     "http://example.com/%25a%2a"},
+                {"http://example.com/%g1%2A",    "http://example.com/%25g1%2a"},
+        };
+
+        for (String[] test: TESTS) {
+            assertEquals("The input '" + test[0] + "' should be error corrected as expected",
+                         test[1], Normalisation.fixURLErrors(test[0]));
         }
     }
 


### PR DESCRIPTION
Handles issues #136, #137, #138 & #139.

- #138 is handled by returning explicit escapes of invalid UTF-8 codepoints. If anyone feels for it, an "assume charset X if not UTF-8" option could be added.
- #136 is handled by adjusting the test. This could also be handled by removing all trailing slashes from domain-level links.
