### PR TITLE
Space should be converted to plus if found in parameter part of URL

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
@@ -150,7 +150,7 @@ public class Normalisation {
                 int codePoint = Integer.parseInt("" + (char) utf8[i + 1] + (char) utf8[i + 2], 16);
                 if (paramSection && codePoint == ' ') { // In parameters, space becomes plus
                     sb.write(0xFF & '+');
-                } else if (mustEscape(codePoint) || !normaliseLowOrder) { // Pass on unmodified
+                } else if (mustEscape(codePoint) || keepEscape(codePoint) || !normaliseLowOrder) { // Pass on unmodified
                     hexEscape(codePoint, sb);
                 } else { // Normalise to ASCII
                     sb.write(0xFF & codePoint);
@@ -218,6 +218,11 @@ public class Normalisation {
     // Some low-order characters must always be escaped
     private static boolean mustEscape(int codePoint) {
         return codePoint == ' ' || codePoint == '%';
+    }
+
+    // If the codePoint is already escaped, keep the escaping
+    private static boolean keepEscape(int codePoint) {
+        return codePoint == '#';
     }
 
     private static boolean isHex(byte b) {

--- a/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
@@ -103,6 +103,25 @@ public class NormalisationTest {
         }
     }
 
+    /* In the URL-path, there can be space and plus. These will be distinct when normalised.
+     * In the URL-arguments, space is often translated to plus so both space and plus will be normalised to plus */
+    @Test
+    public void testSpace() {
+// TODO: What about escaped question marks?    {"http://example.com/%3fpath?q=%3f", "http://example.com/%3fpath?q=%3f"},
+        final String[][] TESTS = new String[][]{
+                {"http://example.com/%20 +path",           "http://example.com/%20%20+path"},
+                {"http://example.com/+%20 path",           "http://example.com/+%20%20path"},
+                {"http://example.com/path?foo=%20 +",      "http://example.com/path?foo=+++"},
+                {"http://example.com/%20 +path?foo=%20 +", "http://example.com/%20%20+path?foo=+++"},
+                {"http://example.com/+%20 path?foo=+%20 ", "http://example.com/+%20%20path?foo=+++"},
+        };
+
+        for (String[] test: TESTS) {
+            assertEquals("The input '" + test[0] + "' should be normalised as expected",
+                         test[1], Normalisation.canonicaliseURL(test[0]));
+        }
+    }
+
     @Test
     public void testFaultyHARDURLNormalisation() {
         final String[][] TESTS = new String[][]{

--- a/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
@@ -130,6 +130,7 @@ public class NormalisationTest {
                 {"http://example.com/10% proof", "http://example.com/10%25%20proof"},
                 {"http://example.com/%a%2A",     "http://example.com/%25a*"},
                 {"http://example.com/%g1%2A",    "http://example.com/%25g1*"},
+                {"http://example.com/hash#%23",  "http://example.com/hash#%23"},
         };
 
         for (String[] test: TESTS) {


### PR DESCRIPTION
A space and a plus are just that in the path-part of an URL, but for parameters space is normally converted to plus. This pull request normalises ` `, `%20` and `+` to `+` in the parameter-part of an URL.

Sample:
`http://example.com/%20 +path?foo=%20 +` (raw)
`http://example.com/%20%20+path?foo=+++` (normalised)