### PR TITLE
Pruning of invalid tag names extracted by JSoup

### DIFF
--- a/warc-indexer/src/test/java/uk/bl/wa/parsers/HtmlFeatureParserTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/parsers/HtmlFeatureParserTest.java
@@ -61,7 +61,9 @@ public class HtmlFeatureParserTest {
 
 	@Test
 	public void JSoupElementsAddedTest() throws Exception {
-		String testHtml = "<b>test<p></b>";
+		// Browsers handle JavaScript with less than signs well, when it is inside script-tags.
+		// Tika treats the content of script-elements as HTML and treats all containing '<something' as tags
+		String testHtml = "<b>test<p></b><script> if (3<a) console.log('something');</script>";
 		String baseUri = "http://example.com/dummy.html";
 		//
 		ByteArrayInputStream stream = new ByteArrayInputStream(
@@ -79,7 +81,7 @@ public class HtmlFeatureParserTest {
 
 		// Also run in through the handler class:
 		stream.reset();
-		innerBasicParseTest(stream, baseUri, 2);
+		innerBasicParseTest(stream, baseUri, 3);
 	}
 
     @Test


### PR DESCRIPTION
At the Royal Danish Library we have a lot of garbage in the tags-list. This is because JSoup treats the content of `script`-elements as HTML: `<script> if (a<b) console.log('foo');</script>` will result in the tags `script` and `b)`.

This pull-request performs light-weight pruning by only accepting valid tags, i.e. tags that satisfies the regular expression `[a-zA-Z0-9]+`. This easy solution has at least two downsides:

1. It does not handle all cases (e.g. `<script> if ( a<b ) console.log('foo');</script>` will give the tage `script` and `b`, since there is a space after `<b` in the JavaScript)
1. Filters out invalid tags that might be interesting from a researcher perspective (e.g. `<vitæ>life</vitæ>`)

Handling the first case is complicated as it requires a tree-like parsing of HTML and as we all know, the Internet is filled with crappy HTML. Handling the second case is also complicated - we could extend the regexp to letters in general and add characters such as underscore and hyphen, but that would also increase the false positives from JavaScript.