### PR TITLE
New field for redirect URL  HTTP 3xx codes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 -----
 
 **NOTE** The changes to the schema mean this version is not compatible with 2.1.0 indexes. We've also moved to Java 7.
-
+* New solr field 'redirect_to_norm'. Will only be used for redirect HTTP 3xx status codes and empty for other statuses. So no change unless you index HTTP 3xx codes. 
 * Refactored and extended URL-normalisation [#115](https://github.com/ukwa/webarchive-discovery/issues/115) and [#119](https://github.com/ukwa/webarchive-discovery/issues/119)
 * Updated performance instrumentation, with break down of time used on common file types
 * Switched to docValues for most fields [#51](https://github.com/ukwa/webarchive-discovery/issues/51)

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
@@ -38,6 +38,7 @@ public interface SolrFields {
 	public static final String SOURCE_FILE_OFFSET = "source_file_offset";
 	public static final String SOURCE_FILE_PATH = "source_file_path";
 	// Intended for building links-graphs. Normalised the same way as SOLR_LINKS
+	public static final String REDIRECT_TO_NORM = "redirect_to_norm"; //for HTTP 3XX codes.
 	public static final String SOLR_URL_NORMALISED = "url_norm";
 	public static final String SOLR_URL_PATH = "url_path";
     public static final String SOLR_STATUS_CODE = "status_code";

--- a/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
@@ -106,6 +106,7 @@
         <field name="text" type="text_general" indexed="true" stored="false" multiValued="true"/>
         <field name="title" type="text_general" indexed="true" stored="true" multiValued="false"/>
         <field name="type" type="string" indexed="true" docValues="true" multiValued="false"/>
+        <field name="redirect_to_norm" type="string" indexed="true" stored="false" docValues="true" multiValued="false"/>
         <field name="url_norm" type="string" indexed="true" stored="false" docValues="true" multiValued="false"/>
         <field name="url_search" type="path" indexed="true" stored="false" docValues="false"/> <!-- search only to save space-->
         <field name="url_path" type="string" indexed="true" stored="false" docValues="true" multiValued="false"/>


### PR DESCRIPTION
For http 3xx (redirect) documents the redirect to url is now indexed.
new scema.xml field:redirect_to_norm
So no change in indexing unless you index http 3XX status codes. (defined in the config.conf for the warc-indexer).
Has been tested in corpus and seems to work correct. The redirect url can be relative, so it had to be resolved compared to the current url.

The branch name should have been 'redirect' instead of referrer, so dont think to much about the branch name, sorry.

/Thomas