### PR TITLE
Configurable field length limit

### DIFF
--- a/warc-hadoop-indexer/src/main/java/uk/bl/wa/hadoop/indexer/WARCIndexerMapper.java
+++ b/warc-hadoop-indexer/src/main/java/uk/bl/wa/hadoop/indexer/WARCIndexerMapper.java
@@ -28,6 +28,7 @@ import uk.bl.wa.annotation.Annotator;
 import uk.bl.wa.hadoop.WritableArchiveRecord;
 import uk.bl.wa.indexer.WARCIndexer;
 import uk.bl.wa.solr.SolrRecord;
+import uk.bl.wa.solr.SolrRecordFactory;
 import uk.bl.wa.solr.SolrWebServer;
 
 @SuppressWarnings( { "deprecation" } )
@@ -48,6 +49,8 @@ public class WARCIndexerMapper extends MapReduceBase implements
 	private int numShards = 1;
     private int numReducers = 10;
 	private Config config;
+
+	private SolrRecordFactory solrFactory = SolrRecordFactory.createFactory(null); // Overridden by innerConfigure
 
 	public WARCIndexerMapper() {
 		try {
@@ -105,7 +108,7 @@ public class WARCIndexerMapper extends MapReduceBase implements
             } catch (NumberFormatException n) {
                 numReducers = 10;
             }
-
+			solrFactory = SolrRecordFactory.createFactory(config);
 		} catch( NoSuchAlgorithmException e ) {
 			LOG.error("WARCIndexerMapper.configure(): " + e.getMessage());
 		} catch (JsonParseException e) {
@@ -126,7 +129,7 @@ public class WARCIndexerMapper extends MapReduceBase implements
 		noRecords++;
 
 		ArchiveRecord rec = value.getRecord();
-		SolrRecord solr = new SolrRecord(key.toString(), rec.getHeader());
+		SolrRecord solr = solrFactory.createRecord(key.toString(), rec.getHeader());
 		try {
 			if (!header.getHeaderFields().isEmpty()) {
 				// Do the indexing:

--- a/warc-hadoop-indexer/src/main/java/uk/bl/wa/hadoop/indexer/WritableSolrRecord.java
+++ b/warc-hadoop-indexer/src/main/java/uk/bl/wa/hadoop/indexer/WritableSolrRecord.java
@@ -17,7 +17,7 @@ import uk.bl.wa.solr.SolrRecord;
 public class WritableSolrRecord  implements Writable, Serializable {
 	private static final long serialVersionUID = -3409886058494054406L;
 	
-	private SolrRecord sr = new SolrRecord();
+	private SolrRecord sr;
 
 	private int partition;
 

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -701,7 +701,7 @@ public class WARCIndexer {
 					solr.addField( SolrFields.SERVER, h.getValue() );
 				if (h.getName().equalsIgnoreCase(HttpHeaders.LOCATION)){
 				    String location = h.getValue(); //This can be relative and must be resolved full				  
-   				    solr.addField(SolrFields.REDIRECT_TO_NORM,  Normalisation.resolveRelative(targetUrl, location));
+   				    solr.setField(SolrFields.REDIRECT_TO_NORM,  Normalisation.resolveRelative(targetUrl, location));
 				}
 				  				 			
 			}

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -92,6 +92,7 @@ import uk.bl.wa.extract.LinkExtractor;
 import uk.bl.wa.parsers.HtmlFeatureParser;
 import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
+import uk.bl.wa.solr.SolrRecordFactory;
 import uk.bl.wa.solr.SolrWebServer;
 import uk.bl.wa.util.HashedCachedInputStream;
 import uk.bl.wa.util.Instrument;
@@ -148,6 +149,8 @@ public class WARCIndexer {
 	// Also canonicalise the HOST field (e.g. drop "www.")
 	public static final boolean CANONICALISE_HOST = true;
 
+	private final SolrRecordFactory solrFactory;
+
 	/* ------------------------------------------------------------ */
 
 	/**
@@ -169,7 +172,7 @@ public class WARCIndexer {
 		} catch (IOException e1) {
 			log.error("Failed to load log4j config from properties file.");
 		}
-
+		solrFactory = SolrRecordFactory.createFactory(conf);
 		// Optional configurations:
 		this.extractText = conf.getBoolean( "warc.index.extract.content.text" );
 		log.info("Extract text = " + extractText);
@@ -298,7 +301,7 @@ public class WARCIndexer {
 	public SolrRecord extract( String archiveName, ArchiveRecord record, boolean isTextIncluded ) throws IOException {      
 	  final long start = System.nanoTime();
 		ArchiveRecordHeader header = record.getHeader();
-		SolrRecord solr = new SolrRecord(archiveName, header);
+		SolrRecord solr = solrFactory.createRecord(archiveName, header);
 		
 		if( !header.getHeaderFields().isEmpty() ) {
 			if( header.getHeaderFieldKeys().contains( HEADER_KEY_TYPE ) ) {

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -69,6 +69,7 @@ import uk.bl.wa.annotation.Annotations;
 import uk.bl.wa.annotation.Annotator;
 import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
+import uk.bl.wa.solr.SolrRecordFactory;
 import uk.bl.wa.solr.SolrWebServer;
 import uk.bl.wa.util.Instrument;
 
@@ -270,6 +271,7 @@ public class WARCIndexerCommand {
 			log.info("Loaded warc config.");
 			log.info(conf.getString("warc.title"));
 		}
+		final SolrRecordFactory solrFactory = SolrRecordFactory.createFactory(conf);
 		if(solrUrl != null) {
 			conf = conf.withValue(SolrWebServer.CONF_HTTP_SERVER, ConfigValueFactory.fromAnyRef(solrUrl) );
 		}
@@ -344,8 +346,7 @@ public class WARCIndexerCommand {
                     log.warn("Exception on record after rec " + recordCount + " from " + inFile.getName(), e);
                     continue;
                 }
-                SolrRecord doc = new SolrRecord(inFile.getName(),
-                                                rec.getHeader());
+                SolrRecord doc = solrFactory.createRecord(inFile.getName(), rec.getHeader());
                 log.debug("Processing record for url "
                         + rec.getHeader().getUrl()
                         + " from " + inFile.getName() + " @"

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecordFactory.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecordFactory.java
@@ -1,0 +1,88 @@
+package uk.bl.wa.solr;
+
+/*
+ * #%L
+ * warc-indexer
+ * $Id:$
+ * $HeadURL:$
+ * %%
+ * Copyright (C) 2013 - 2014 The UK Web Archive
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.typesafe.config.ConfigValue;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import com.typesafe.config.Config;
+import org.archive.io.ArchiveRecordHeader;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Config supporting factory for {@link SolrRecord}, making it possible to specify limits on Solr fields.
+ */
+public class SolrRecordFactory {
+    private static Log log = LogFactory.getLog(SolrRecordFactory.class);
+
+    public static final String KEY_DEFAULT_MAX = "warc.solr.field_setup.default_max_length";
+    public static final String KEY_FIELD_LIST = "warc.solr.field_setup.fields";
+    public static final String KEY_MAX = "max_length";
+
+    public static final int DEFAULT_MAX_LENGTH = -1; // -1 = no limit
+
+    private final int defaultMax;
+    private final HashMap<String, Integer> maxLengths = new HashMap<>(); // Explicit HashMap as it is Serializable
+
+    public static SolrRecordFactory createFactory(Config config) {
+        return new SolrRecordFactory(config);
+    }
+
+    private SolrRecordFactory(Config config) {
+        defaultMax = config != null && config.hasPath(KEY_DEFAULT_MAX) ?
+                config.getInt(KEY_DEFAULT_MAX) : DEFAULT_MAX_LENGTH;
+        StringBuilder sb = new StringBuilder();
+        if (config != null && config.hasPath(KEY_FIELD_LIST)) {
+            for (Map.Entry<String, ConfigValue> cv : config.getObject(KEY_FIELD_LIST).entrySet()) {
+                String field = cv.getKey();
+                String maxKey = KEY_FIELD_LIST + "." + field + "." + KEY_MAX;
+                if (config.hasPath(maxKey)) {
+                    long max = config.getBytes(KEY_FIELD_LIST + "." + field + "." + KEY_MAX);
+                    if (max > Integer.MAX_VALUE) {
+                        log.error("The limit " + max + " for field " + field + " exceeds Integer.MAX_VALUE");
+                        continue;
+                    }
+                    if (sb.length() > 0) {
+                        sb.append(", ");
+                    }
+                    sb.append(field).append("=").append(max);
+                    maxLengths.put(field, (int) max);
+                }
+            }
+        }
+        log.info("Created SolrRecordFactory(defaultMaxLength=" + defaultMax + ", maxLengths=[" + sb + "])");
+    }
+
+    public SolrRecord createRecord() {
+        return new SolrRecord(defaultMax, maxLengths);
+    }
+
+    public SolrRecord createRecord(String filename, ArchiveRecordHeader header) {
+        return new SolrRecord(defaultMax, maxLengths, filename, header);
+    }
+
+}

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/WctEnricher.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/WctEnricher.java
@@ -44,7 +44,7 @@ public class WctEnricher {
 
 	public WctEnricher( String archiveName ) {
 		String wctID = this.getWctTi( archiveName );
-		solr = new SolrRecord();
+		solr = SolrRecordFactory.createFactory(null).createRecord(); // Never reduces field length size
 		solr.setField( WctFields.WCT_INSTANCE_ID, wctID );
 		getWctMetadata( solr );
 	}

--- a/warc-indexer/src/main/resources/reference.conf
+++ b/warc-indexer/src/main/resources/reference.conf
@@ -166,6 +166,17 @@
             "dummy_run" : false,
             # Disable explicit commit
             "disablecommit" : false,
+
+            # field-specific setup
+            "field_setup" : {
+                "default_max_length" : -1,
+                "fields" : {
+                    "url" :      { "max_length" : 2048 }, # de facto max length for GET URLs
+                    "url_norm" : { "max_length" : 2048 },
+                    "links" :    { "max_length" : 2048 },
+                    "content" :  { "max_length" : 512K }, # Same as tika.max_text_length
+                },
+            },
         },
         
         # HTTP Proxy to use when talking to Solr (if any):

--- a/warc-indexer/src/test/java/uk/bl/wa/analyser/payload/HTMLAnalyserTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/analyser/payload/HTMLAnalyserTest.java
@@ -44,6 +44,7 @@ import com.typesafe.config.ConfigFactory;
 
 import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
+import uk.bl.wa.solr.SolrRecordFactory;
 
 /**
  * @author Toke Eskildsen <te@statsbiblioteket.dk>
@@ -74,7 +75,7 @@ public class HTMLAnalyserTest {
         core.put("absolute-offset", "0");
         core.put("origin", "");
         ArchiveRecordHeader header = new ARCRecordMetaData("invalid", core);
-        SolrRecord solr = new SolrRecord();
+        SolrRecord solr = SolrRecordFactory.createFactory(null).createRecord();
         InputStream in = new BufferedInputStream(new FileInputStream(SAMPLE), (int) SAMPLE.length());
         in.mark((int) SAMPLE.length());
         ha.analyse(header, in, solr);

--- a/warc-indexer/src/test/java/uk/bl/wa/analyser/payload/WARCPayloadAnalysersTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/analyser/payload/WARCPayloadAnalysersTest.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.commons.logging.Log;
 import org.archive.io.ArchiveRecordHeader;
 import uk.bl.wa.solr.SolrRecord;
+import uk.bl.wa.solr.SolrRecordFactory;
 
 import java.util.Map;
 import java.util.Set;
@@ -47,7 +48,7 @@ public class WARCPayloadAnalysersTest extends TestCase {
         ARCNameAnalyser ana = getAnalyser();
 
         ArchiveRecordHeader header = new FakeHeader("whatever/localrun-job87-20150219-133227.warc");
-        SolrRecord solr = new SolrRecord();
+        SolrRecord solr = SolrRecordFactory.createFactory(null).createRecord();
         ana.analyse(header, null, solr);
         assertEquals("The solr documents should have the right content for field harvest_job",
                      "job87", (solr.getFieldValue("harvest_job").toString()));
@@ -107,7 +108,7 @@ public class WARCPayloadAnalysersTest extends TestCase {
                         "/netarkiv/0116/filedir/276809-272-20170622193108196-00004-kb-prod-har-001.kb.dk.warc.gz"
                 }
         }) {
-            SolrRecord solr = new SolrRecord();
+            SolrRecord solr = SolrRecordFactory.createFactory(null).createRecord();
             ana.analyse(new FakeHeader(test[1]), null, solr);
 
             for (String expectedPair:test[0].split(" *, *")) {

--- a/warc-indexer/src/test/java/uk/bl/wa/indexer/WARCIndexerTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/indexer/WARCIndexerTest.java
@@ -50,6 +50,7 @@ import com.typesafe.config.ConfigValueFactory;
 
 import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
+import uk.bl.wa.solr.SolrRecordFactory;
 
 import static org.junit.Assert.*;
 
@@ -343,7 +344,7 @@ public class WARCIndexerTest {
                 "http://www.bbc.co.uk/news/business/market_data/chart?chart_primary_ticker=MISCAM:GOLDAM&chart_time_period=1_month&canvas_co",
                 "http://www.bbc.co.uk/news/business/market_data/chart?chart_primary_ticker=FX^GBP:ILS&chart_time_period=1_month&canvas_colour" };
         for (String urlString : testUrls) {
-            SolrRecord solr = new SolrRecord();
+            SolrRecord solr =  SolrRecordFactory.createFactory(null).createRecord();
             URI test1 = windex.parseURL(solr, urlString);
             assertEquals(1,
                     solr.getField(SolrFields.PUBLIC_SUFFIX).getValueCount());

--- a/warc-indexer/src/test/java/uk/bl/wa/solr/SolrRecordFactoryTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/solr/SolrRecordFactoryTest.java
@@ -1,0 +1,83 @@
+package uk.bl.wa.solr;
+
+/*
+ * #%L
+ * warc-indexer
+ * %%
+ * Copyright (C) 2013 - 2018 The UK Web Archive
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.impl.ConfigImpl;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import com.typesafe.config.Config;
+
+import java.io.File;
+import java.net.URL;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+public class SolrRecordFactoryTest {
+
+    @Test
+    public void testBasicFactorySetup() {
+        final String KEY_URL_MAX_LENGTH = "warc.solr.field_setup.fields.url.max_length";
+
+        URL ref = Thread.currentThread().getContextClassLoader().getResource("reference.conf");
+        assertNotNull("The config reference.conf should exist", ref);
+        File configFilePath = new File(ref.getFile());
+        Config conf = ConfigFactory.parseFile(configFilePath);
+        assertTrue("Max for url field should be specified with key " + KEY_URL_MAX_LENGTH,
+                   conf.hasPath(KEY_URL_MAX_LENGTH));
+        SolrRecordFactory factory = SolrRecordFactory.createFactory(conf);
+
+        {
+            SolrRecord record = factory.createRecord();
+            final String FAKE_URL = "short";
+            record.addField("url", FAKE_URL);
+            assertEquals("The length of the url field with a short String should be unchanged",
+                         FAKE_URL.length(), record.getFieldValue("url").toString().length());
+        }
+        {
+            SolrRecord record = factory.createRecord();
+            StringBuilder fakeURL = new StringBuilder(4000);
+            fakeURL.append("short");
+            for (int i = 0 ; i < 2500 ; i++) {
+                fakeURL.append("O");
+            }
+            record.addField("url", fakeURL.toString());
+            assertEquals("The length of the url field with a huge String should be trimmed",
+                         conf.getBytes(KEY_URL_MAX_LENGTH).intValue(),
+                         record.getFieldValue("url").toString().length());
+        }
+    }
+}

--- a/warc-indexer/src/test/java/uk/bl/wa/solr/TikaExtractorTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/solr/TikaExtractorTest.java
@@ -31,6 +31,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.net.URL;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,6 +41,7 @@ import org.junit.Test;
  *
  */
 public class TikaExtractorTest {
+	private static Log log = LogFactory.getLog(TikaExtractorTest.class);
 
 	private TikaExtractor tika;
 
@@ -52,10 +55,13 @@ public class TikaExtractorTest {
 
 	@Test
 	public void testMonaLisa() throws Exception {
-		File ml = new File(
-				"src/test/resources/wikipedia-mona-lisa/Mona_Lisa.html");
+		File ml = new File("src/test/resources/wikipedia-mona-lisa/Mona_Lisa.html");
+		if (!ml.exists()) {
+			log.error("The Mona Lisa test file '" + ml + "' does not exist");
+			return;
+		}
 		URL url = ml.toURI().toURL();
-		SolrRecord solr = new SolrRecord();
+		SolrRecord solr = SolrRecordFactory.createFactory(null).createRecord();
 		tika.extract(solr, url.openStream(), url.toString());
 		System.out.println("SOLR " + solr.getSolrDocument().toString());
 		String text = (String) solr.getField(SolrFields.SOLR_EXTRACTED_TEXT)


### PR DESCRIPTION
We (at Royal Danish Library) are not comfortable with the full disabling the max Solr field length feature, especially not for things like `links` extraction. This pull request makes the max limits for fields configurable on a field-per-field basis. `reference.conf` has been updated with the following section, which should demonstrate how this works:
```
# field-specific setup
"field_setup" : {
    "default_max_length" : -1,
        "fields" : {
            "url" :      { "max_length" : 2048 }, # de facto max length for GET URLs
            "url_norm" : { "max_length" : 2048 },
            "links" :    { "max_length" : 2048 },
            "content" :  { "max_length" : 512K }, # Same as tika.max_text_length
        },
    },
```
The format layout has been chosen in anticipation of extension. One candidate could be to introduce a limit on the number of entries for the field, e.g. to guard against an excessive amount of links from a page in the `links`-field.