### PR TITLE
Fix infinite loop when the last record is corrupted

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -350,6 +350,7 @@ public class WARCIndexerCommand {
                         lastFailedRecord = recordCount;
                         continue;
                     }
+                    log.error("Failed to reach next record, last record already on error - skipping the rest of the records");
                     break;
                 }
                 final String url = Normalisation.sanitiseWARCHeaderValue(rec.getHeader().getUrl());

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -336,6 +336,7 @@ public class WARCIndexerCommand {
             ArchiveReader reader = ArchiveReaderFactory.get(inputFile);
             Iterator<ArchiveRecord> ir = reader.iterator();
             int recordCount = 1;
+            int lastFailedRecord = 0;
 
             // Iterate though each record in the WARC file
             while (ir.hasNext()) {
@@ -345,7 +346,11 @@ public class WARCIndexerCommand {
                     rec = ir.next();
                 } catch (RuntimeException e) {
                     log.warn("Exception on record after rec " + recordCount + " from " + inFile.getName(), e);
-                    continue;
+                    if (lastFailedRecord != recordCount) {
+                        lastFailedRecord = recordCount;
+                        continue;
+                    }
+                    break;
                 }
                 final String url = Normalisation.sanitiseWARCHeaderValue(rec.getHeader().getUrl());
                 SolrRecord doc = solrFactory.createRecord(inFile.getName(), rec.getHeader());


### PR DESCRIPTION
Fix for issue #165.
If the current corrupted record has the same recordCount, it's the same one, so it ends the indexer. 