### PR TITLE
URL normalisation/canonicalisation fixes

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
@@ -149,6 +149,16 @@ public class Normalisation {
             }
         }
 
+        // Create temporary url with %-fixing and high-order characters represented directly
+        byte[] urlBytes = fixEscapeErrorsAndUnescapeHighOrderUTF8(url);
+        // Normalise
+
+
+        // Hex escapes, including faulty hex escape handling:
+        // http://example.com/all%2A rosé 10%.html → http://example.com/all*%20rosé%2010%25.html or
+        // http://example.com/all%2A rosé 10%.html → http://example.com/all*%20ros%C3%A9%2010%25.html if produceValidURL
+        url = escapeUTF8(urlBytes, !allowHighOrder, createUnambiguous);
+
         // TODO: Consider if this should only be done if createUnambiguous == true
         // Trailing slashes: http://example.com/foo/ → http://example.com/foo
         while (url.endsWith("/")) { // Trailing slash affects the URL semantics
@@ -159,16 +169,6 @@ public class Normalisation {
         if (DOMAIN_ONLY.matcher(url).matches()) {
             url += "/";
         }
-
-        // Create temporary url with %-fixing and high-order characters represented directly
-        byte[] urlBytes = fixEscapeErrorsAndUnescapeHighOrderUTF8(url);
-        // Normalise
-
-
-        // Hex escapes, including faulty hex escape handling:
-        // http://example.com/all%2A rosé 10%.html → http://example.com/all*%20rosé%2010%25.html or
-        // http://example.com/all%2A rosé 10%.html → http://example.com/all*%20ros%C3%A9%2010%25.html if produceValidURL
-        url = escapeUTF8(urlBytes, !allowHighOrder, createUnambiguous);
 
         return url;
     }

--- a/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
@@ -173,7 +173,7 @@ public class Normalisation {
         return url;
     }
     private static Pattern DOMAIN_ONLY = Pattern.compile("https?://[^/]+");
-    private static Pattern WWW_PREFIX = Pattern.compile("([a-z]+://)(?:www|ww2|www2|ww)[.](.+)");
+    private static Pattern WWW_PREFIX = Pattern.compile("([a-z]+://)(?:www[0-9]*|ww2|ww)[.](.+)");
 
     // Normalisation to UTF-8 form
     private static byte[] fixEscapeErrorsAndUnescapeHighOrderUTF8(final String url) {

--- a/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
@@ -283,8 +283,9 @@ public class Normalisation {
     private final static byte[] HEX = "0123456789abcdef".getBytes(UTF8_CHARSET); // Assuming lowercase
 
     // Some low-order characters must always be escaped
+    // TODO: Consider adding all unwise characters from https://www.ietf.org/rfc/rfc2396.txt : {|}\^[]`
     private static boolean mustEscape(int codePoint) {
-        return codePoint == ' ' || codePoint == '%';
+        return codePoint == ' ' || codePoint == '%' || codePoint == '\\';
     }
 
     // If the codePoint is already escaped, keep the escaping

--- a/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/Normalisation.java
@@ -33,6 +33,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -140,6 +141,14 @@ public class Normalisation {
         // Protocol: https → http
         url = url.startsWith("https://") ? "http://" + url.substring(8) : url;
 
+        // www. prefix
+        if (createUnambiguous) {
+            Matcher wwwMatcher = WWW_PREFIX.matcher(url);
+            if (wwwMatcher.matches()) {
+                url = wwwMatcher.group(1) + wwwMatcher.group(2);
+            }
+        }
+
         // TODO: Consider if this should only be done if createUnambiguous == true
         // Trailing slashes: http://example.com/foo/ → http://example.com/foo
         while (url.endsWith("/")) { // Trailing slash affects the URL semantics
@@ -164,6 +173,7 @@ public class Normalisation {
         return url;
     }
     private static Pattern DOMAIN_ONLY = Pattern.compile("https?://[^/]+");
+    private static Pattern WWW_PREFIX = Pattern.compile("([a-z]+://)(?:www|ww2|www2|ww)[.](.+)");
 
     // Normalisation to UTF-8 form
     private static byte[] fixEscapeErrorsAndUnescapeHighOrderUTF8(final String url) {

--- a/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
@@ -64,11 +64,22 @@ public class NormalisationTest {
                 {"http://example.com/foo | bar/",   "sub/", "http://example.com/foo | bar/sub/", "false"},
                 {"http://example.com/faulty%g/gg",  "sub", "http://example.com/faulty%25g/sub", "true"},
                 {"http://example.com/faulty%g/gg",  "sub", "http://example.com/faulty%g/sub", "false"},
+                {"http://www.example.com/faulty%g/gg",  "sub", "http://example.com/faulty%25g/sub", "true"},
+                {"http://www.example.com/faulty%g/gg",  "sub", "http://www.example.com/faulty%g/sub", "false"},
         };
         for (String[] test: TESTS) {
             assertEquals("rel('" + test[0] + "', '" + test[1] + "', " + test[3] + ") should give the expected result",
                          test[2], Normalisation.resolveRelative(test[0], test[1], Boolean.parseBoolean(test[3])));
         }
+    }
+
+    // The canonicalizer from archive.org removes www if the URL has a path part and not if it is domain only
+    @Test
+    public void testWWWRemoveOnNormalisation() {
+        String SOURCE =   "http://www.example.com/";
+        String EXPECTED = "http://example.com/";
+        assertEquals("The input '" + SOURCE + "' should be normalised unambiguously as expected",
+                     EXPECTED, Normalisation.canonicaliseURL(SOURCE, true, true));
     }
 
     @Test
@@ -79,6 +90,10 @@ public class NormalisationTest {
                 {"http://example.com/", "http://example.com/", "http://example.com/"},
                 {"https://example.com", "http://example.com/", "http://example.com/"},
                 {"https://example.com", "http://example.com/", "http://example.com/"},
+                {"http://www.example.com",  "http://www.example.com/", "http://example.com/"},
+                {"https://www.example.com", "http://www.example.com/", "http://example.com/"},
+                {"https://ww2.example.com", "http://ww2.example.com/", "http://example.com/"},
+                {"http://ww2.example.com",  "http://ww2.example.com/", "http://example.com/"},
                 {"/foo",                "/foo",                "/foo"},
                 {"/foo/",               "/foo",                "/foo"},
                 {"/%2A",                "/%2a",                "/*"},
@@ -121,6 +136,7 @@ public class NormalisationTest {
                 {"http://example.com/%C3%86blegr%C3",     "http://example.com/Æblegr%c3"},    // Half UTF-8 2-byte escape
                 {"http://example.com/Æblegrød",           "http://example.com/æblegrød"},     // Direct unicode
                 {"http://example.com/%C6blegr%F8d",       "http://example.com/%c6blegr%f8d"}, // ISO-8859-1
+                {"http://www.example.com/%C6blegr%F8d",   "http://example.com/%c6blegr%f8d"}, // ISO-8859-1
         };
 
         for (String[] test: TESTS) {
@@ -138,6 +154,7 @@ public class NormalisationTest {
                 {"http://example.com/%a%2A",     "http://example.com/%25a%2a"},
                 {"http://example.com/%g1%2A",    "http://example.com/%25g1%2a"},
                 {"http://example.com/foo|bar",   "http://example.com/foo|bar"},
+                {"http://www.example.com/foo|bar", "http://example.com/foo|bar"},
         };
 
         for (String[] test: TESTS) {

--- a/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
@@ -121,7 +121,9 @@ public class NormalisationTest {
                 {"%C3%A6blegr%C3%B8d",  "æblegrød",            "æblegrød"},
                 {"/æblegrød og øl",     "/æblegrød%20og%20øl", "/æblegrød%20og%20øl"},
                 {"Red, Rosé 14%",       "red,%20rosé%2014%25", "red,%20rosé%2014%25"},
-                {"Red%2C%20Ros%C3%A9 14%25", "red%2c%20rosé%2014%25",  "red,%20rosé%2014%25"}
+                {"Red%2C%20Ros%C3%A9 14%25", "red%2c%20rosé%2014%25",  "red,%20rosé%2014%25"},
+                {"/backslash\\",        "/backslash%5c",       "/backslash%5c"},
+                {"/backslash%5C",       "/backslash%5c",       "/backslash%5c"},
         };
 
         for (String[] test: TESTS) {

--- a/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
@@ -49,6 +49,24 @@ public class NormalisationTest {
     }
 
     @Test
+    public void testEncodedTrailingSlash() {
+        String[][] TESTS = new String[][]{
+                {
+                        "https://www.example.com/foo?param=https://www.example.com/other/",
+                        "http://example.com/foo?param=https://www.example.com/other"
+                },
+                {
+                        "https://www.example.com/foo?param=https:%2F%2Fwww.example.com%2Fother%2F",
+                        "http://example.com/foo?param=https://www.example.com/other"
+                }
+        };
+        for (String[] test: TESTS) {
+            assertEquals("Default normalisation should yield the expected result for " + test[0],
+                         test[1], Normalisation.canonicaliseURL(test[0]));
+        }
+    }
+
+    @Test
     public void restResolveRelative() {
         String[][] TESTS = new String[][]{
                 // root, relative, expected

--- a/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
@@ -111,6 +111,7 @@ public class NormalisationTest {
                 {"http://www.example.com",  "http://www.example.com/", "http://example.com/"},
                 {"https://www.example.com", "http://www.example.com/", "http://example.com/"},
                 {"https://ww2.example.com", "http://ww2.example.com/", "http://example.com/"},
+                {"https://www8.example.com", "http://www8.example.com/", "http://example.com/"},
                 {"http://ww2.example.com",  "http://ww2.example.com/", "http://example.com/"},
                 {"/foo",                "/foo",                "/foo"},
                 {"/foo/",               "/foo",                "/foo"},


### PR DESCRIPTION
Fore reasons unknown, the canonicalization code from archive.org normalises `http://www.example.com/foo.bar` to `http://example.com/foo.bar` (it removes the `www.`-part), but normalises `http://www.example.com/` to `http://www.example.com/` (no change to the `www.`-part). Thanks for that, archive.org (I am sure they had good reasons, but it is quite vexing for me).

This pull request does an explicit check for `www.`-prefix and the other `w`-prefixes mentioned in #155.

With this, coupling `links` to `url_norm` should work for the vast majority of URLs.