### PR TITLE
Weekday & time of day

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -487,8 +488,7 @@ public class WARCIndexer {
 						if (results.getResults().size() > 0) {
 							SolrDocument fr = results.getResults().get(0);
 							if (fr.containsKey(SolrFields.CRAWL_DATES)) {
-								for (Object cds : fr
-										.getFieldValues(SolrFields.CRAWL_DATES)) {
+								for (Object cds : fr.getFieldValues(SolrFields.CRAWL_DATES)) {
 									currentCrawlDates.add((Date) cds);
 								}
 							}
@@ -525,8 +525,9 @@ public class WARCIndexer {
 			dateList.add(crawlDate);
 			Collections.sort(dateList);
 			Date firstDate = dateList.get(0);
-			solr.setField(SolrFields.CRAWL_DATE,
-					formatter.format(firstDate));
+			solr.setField(SolrFields.CRAWL_DATE, formatter.format(firstDate));
+			solr.setField(SolrFields.CRAWL_WEEKDAY, formatter_weekday.format(firstDate));
+			solr.setField(SolrFields.CRAWL_TIME_OF_DAY, formatter_time_of_day.format(firstDate));
 			solr.setField( SolrFields.CRAWL_YEAR, getYearFromDate(firstDate) );
 			
 			// Use the current value as the waybackDate:
@@ -755,12 +756,15 @@ public class WARCIndexer {
 
 	/**
 	 * Timestamp parsing, for the Crawl Date.
+	 * Note: DateFormatters are not Thread safe
 	 */
 
-	public static SimpleDateFormat formatter = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	public static SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+	public static SimpleDateFormat formatter_weekday = new SimpleDateFormat("EEEE", Locale.ENGLISH);
+	public static SimpleDateFormat formatter_time_of_day = new SimpleDateFormat("'0001-01-01T'HH:mm:ss'Z'");
 	static {
 		formatter.setTimeZone( TimeZone.getTimeZone( "GMT" ) );
+		formatter_weekday.setTimeZone( TimeZone.getTimeZone( "GMT" ) );
 	}
 
 	/**

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrFields.java
@@ -112,11 +112,15 @@ public interface SolrFields {
 	public static final String WAYBACK_DATE = "wayback_date";
 	public static final String CRAWL_DATE = "crawl_date";
 	public static final String CRAWL_DATES = "crawl_dates";
+	public static final String CRAWL_WEEKDAY = "crawl_weekday";
+	public static final String CRAWL_TIME_OF_DAY = "crawl_time_of_day";
 	public static final String CRAWL_YEAR = "crawl_year";
 	public static final String CRAWL_YEARS = "crawl_years";
 	public static final String PUBLICATION_DATE = "publication_date"; // Does not seem to be used
 	public static final String PUBLICATION_YEAR = "publication_year"; // Does not seem to be used
 	public static final String LAST_MODIFIED = "last_modified";
+	public static final String LAST_MODIFIED_WEEKDAY = "last_modified_weekday";
+	public static final String LAST_MODIFIED_TIME_OF_DAY = "last_modified_time_of_day";
 	public static final String LAST_MODIFIED_YEAR = "last_modified_year";
 		
 	//Image Exif metadata

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/TikaExtractor.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/TikaExtractor.java
@@ -32,6 +32,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.lang.StringUtils;
@@ -348,6 +349,9 @@ mime_exclude = x-tar,x-gzip,bz,lz,compress,zip,javascript,css,octet-stream,image
 					// solr.getSolrDocument().setField(SolrFields.LAST_MODIFIED,
 					// edate);
 					solr.setField(SolrFields.LAST_MODIFIED, iso_df.print(edate));
+					solr.setField(SolrFields.LAST_MODIFIED_TIME_OF_DAY,
+								  ISODateTimeFormat.basicTimeNoMillis().withZoneUTC().print(edate));
+					solr.setField(SolrFields.LAST_MODIFIED_TIME_OF_DAY, edate.dayOfWeek().getAsText(Locale.ENGLISH));
 				}
 			}
 			

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/TikaExtractor.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/TikaExtractor.java
@@ -350,8 +350,8 @@ mime_exclude = x-tar,x-gzip,bz,lz,compress,zip,javascript,css,octet-stream,image
 					// edate);
 					solr.setField(SolrFields.LAST_MODIFIED, iso_df.print(edate));
 					solr.setField(SolrFields.LAST_MODIFIED_TIME_OF_DAY,
-								  ISODateTimeFormat.basicTimeNoMillis().withZoneUTC().print(edate));
-					solr.setField(SolrFields.LAST_MODIFIED_TIME_OF_DAY, edate.dayOfWeek().getAsText(Locale.ENGLISH));
+								  "0001-01-01T" + ISODateTimeFormat.hourMinuteSecond().withZoneUTC().print(edate));
+					solr.setField(SolrFields.LAST_MODIFIED_WEEKDAY, edate.dayOfWeek().getAsText(Locale.ENGLISH));
 				}
 			}
 			

--- a/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr/discovery/conf/schema.xml
@@ -64,6 +64,8 @@
         <field name="content_type_version" type="string" indexed="true" docValues="true" multiValued="false"/>
         <field name="crawl_dates" type="tdate" indexed="true" stored="true" multiValued="true"/>
         <field name="crawl_date" type="tdate" indexed="true" stored="false" multiValued="false" docValues="true"/>
+        <field name="crawl_weekday" type="string" indexed="true" stored="false" multiValued="false" docValues="true"/>
+        <field name="crawl_time_of_day" type="tdate" indexed="true" stored="false" multiValued="false" docValues="true"/>
         <field name="crawl_year_month_day" type="int" indexed="true" docValues="true" multiValued="false"/>
         <field name="crawl_year_month" type="int" indexed="true" docValues="true" multiValued="false"/>
         <field name="crawl_years" type="int" indexed="true" docValues="true" multiValued="true"/>
@@ -87,6 +89,8 @@
         <field name="image_width" type="tlong" indexed="true" stored="false" docValues="true" multiValued="false"/>
         <field name="keywords" type="text_general" indexed="true" stored="true"/>
         <field name="last_modified" type="tdate" indexed="true" stored="false" docValues="true"/>
+        <field name="last_modified_weekday" type="string" indexed="true" stored="false" multiValued="false" docValues="true"/>
+        <field name="last_modified_time_of_day" type="date" indexed="true" stored="false" multiValued="false" docValues="true"/>
         <field name="last_modified_year" type="string" indexed="true" docValues="true"/>
         <field name="license_url" type="string" indexed="true" docValues="true" multiValued="true"/>
         <field name="links_images" type="string" indexed="true" docValues="true" multiValued="true"/> 

--- a/warc-indexer/src/main/solr/solr7/discovery/conf/schema.xml
+++ b/warc-indexer/src/main/solr/solr7/discovery/conf/schema.xml
@@ -140,6 +140,20 @@ This schema is for Solr 7+ and will not work under Solr 6.
         <!-- month_day & day not used for anything -->
 <!--        <field name="crawl_year_month_day" type="int" />
         <field name="crawl_year_month"     type="int" />-->
+        <!-- The weekday extracted from crawl_date (Monday, Tuesday, Wednesday...).
+             Sample use: Limiting searches to crawls done between Friday evening and Saturday morning:
+             fq=(crawl_weekday:Friday AND crawl_time_of_day:[0001-01-01T19:00:00Z TO *]) OR (crawl_weekday:Saturday AND crawl_time_of_day:[* TO 0001-01-01T6:00:00Z])
+             Note: This makes little sense for standard web resources as the crawl-time does not reflect when the
+             resource was created.
+        -->
+        <field name="crawl_weekday"        type="string" />
+        <!-- The time of the day extracted from crawl_date, represented by fixing the date to 0001-01-01.
+             Sample use: Limiting searches to data harvested around noon:
+             fq=crawl_time_of_day:[0001-01-01T11:00:00Z TO 0001-01-01T14:00:00Z]
+             Note: This makes little sense for standard web resources as the crawl-time does not reflect when the
+             resource was created.
+        -->
+        <field name="crawl_time_of_day"    type="date" />
         <!-- If webarchive-discovery runs in update-mode, multiple harvests of the same URL will be collapsed to
              a single document and the years from the dates from the different harvests will be added to this field -->
         <field name="crawl_years"          type="int" multiValued="true" />
@@ -151,10 +165,22 @@ This schema is for Solr 7+ and will not work under Solr 6.
              Note: This is not a very reliable timestamp for most formats. JPEGs tend to work quite well.
              Sample use: Sorting by age as stated in the format sort=last_modified asc -->
         <field name="last_modified"        type="date" />
+        <!-- The weekday extracted from last_modified (Monday, Tuesday, Wednesday...).
+             Sample use: Limiting searches to resources from Friday evening and Saturday morning:
+             fq=(crawl_weekday:Friday AND crawl_time_of_day:[0001-01-01T19:00:00Z TO *]) OR (crawl_weekday:Saturday AND crawl_time_of_day:[* TO 0001-01-01T6:00:00Z])
+             Note: This works very well for resources where the timestamp is valid, such as Twitter & Jodel posts.
+        -->
+        <field name="las_modified_weekday" type="string" />
+        <!-- The time of the day extracted from last_modified, represented by fixing the date to 0001-01-01.
+             Sample use: Limiting searches to resources created/updated around noon:
+             fq=last_modified_time_of_day:[0001-01-01T11:00:00Z TO 0001-01-01T14:00:00Z]
+             Note: This works very well for resources where the timestamp is valid, such as Twitter & Jodel posts.
+        -->
+        <field name="last_modified_time_of_day" type="date" />
         <!-- The year from last_modified -->
         <field name="last_modified_year"   type="string" /> <!-- Why is this a string? -->
 
-        <!-- Heavily normalised URL: http/https is collepsed to http, everything is lowercased, trailing / are removed
+        <!-- Heavily normalised URL: http/https is collapsed to http, everything is lowercased, trailing / are removed
              for all URLs, except those pointing to root, e.g. "http://example.com/". There is more processing than
              that. If the field is to be queried with a user-provided URL, it is highly recommended to use the method
              Normalisation.canonicaliseURL() from webarchive-discovery to ensure match.


### PR DESCRIPTION
We have two timestamps: `crawl_date`, which is authoritative from the crawler, and `last_modified`, which is extracted by Tika from the source data. This pull request adds `weekday` (Monday, Tuesday, Wednesday...) and `time_of_day` (16:44:30) to both of these fields. As Solr has no concept of time without a full date, the `time_of_day` is prefixed with `0001-01-01`. Indexing this ways means that date math works as expected. An alternative way would be to have `second_of_day` or something like that, but that requires translation from the user interface.

The use-cases for `last_modified` are fairly obvious: e.g. with this, it is possible to find images taken from Friday evening to Saturday morning.

It is more dubious for `crawl_date` as that timestamp does not say much about when the material was created. It might be useful for debugging crawls? I would appreciate input on whether the `crawl_date`-additions should be included or not.

This pull request closes #161.