### PR TITLE
Droid WARC URL header sanitize

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/DroidDetectorAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/DroidDetectorAnalyser.java
@@ -101,9 +101,9 @@ public class DroidDetectorAnalyser extends AbstractPayloadAnalyser {
                 // Pass the URL in so DROID can fall back on that:
                 Metadata metadata = new Metadata();
                 if (passUriToFormatTools) {
-                    UsableURI uuri = UsableURIFactory
-                            .getInstance(Normalisation
-                                    .fixURLErrors(header.getUrl()));
+                    UsableURI uuri = UsableURIFactory.getInstance(
+                            Normalisation.fixURLErrors(
+                                    Normalisation.sanitiseWARCHeaderValue(header.getUrl())));
                     // Droid seems unhappy about spaces in filenames, so hack to
                     // avoid:
                     String cleanUrl = uuri.getName().replace(" ", "+");


### PR DESCRIPTION
The tool `wget` produces WARC-files with the values for the WARC-header `WARC-Target-URI` encapsulated in `<>`. Retrieving the URL from the WARC header in `warc-indexer` can be done safely using `Normalisation.sanitiseWARCHeaderValue` but this was not done for `DroidDetectorAnalyser`. This pull request fixes that.

This is an oversight that I am sure will come back to bite us, so I have raised issue #197.