### PR TITLE
Webrecorder support

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/TikaPayloadAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/TikaPayloadAnalyser.java
@@ -64,6 +64,7 @@ import de.l3s.boilerpipe.extractors.ArticleExtractor;
 import uk.bl.wa.extract.Times;
 import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
+import uk.bl.wa.util.InputStreamUtils;
 import uk.bl.wa.util.Instrument;
 import uk.bl.wa.util.Normalisation;
 import uk.bl.wa.util.TimeLimiter;
@@ -228,13 +229,24 @@ mime_exclude = x-tar,x-gzip,bz,lz,compress,zip,javascript,css,octet-stream,image
     @SuppressWarnings( "deprecation" )
     public SolrRecord extract( String source, SolrRecord solr, InputStream is, String url ) throws IOException {
 
-        // Set up the TikaInputStream:
-        TikaInputStream tikainput = null;
-        if( this.maxBytesToParser  > 0 ) {
-            tikainput = TikaInputStream.get( new BoundedInputStream( new CloseShieldInputStream(is), maxBytesToParser ) );
-        } else {
-            tikainput = TikaInputStream.get( new CloseShieldInputStream(is) );
+
+        InputStream is_fixed = null;
+        InputStream tikainput= null;
+        try{
+          is_fixed = InputStreamUtils.maybeDecompress(is);
+
         }
+        catch(Exception e){
+          log.error("Error in maybeDecompress gzip");
+          is_fixed = is;
+        }
+        
+        if( this.maxBytesToParser  > 0 ) {
+            tikainput = TikaInputStream.get( new BoundedInputStream( new CloseShieldInputStream(  is_fixed), maxBytesToParser ) );
+        } else {
+            tikainput = TikaInputStream.get( new CloseShieldInputStream(  is_fixed) );
+        }
+        
         
         // Also pass URL as metadata to allow extension hints to work:
         Metadata metadata = new Metadata();
@@ -669,4 +681,5 @@ mime_exclude = x-tar,x-gzip,bz,lz,compress,zip,javascript,css,octet-stream,image
          return decimalDegrees;        
        }
 
+          
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/parsers/HtmlFeatureParser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/parsers/HtmlFeatureParser.java
@@ -54,6 +54,7 @@ import org.xml.sax.SAXException;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import uk.bl.wa.util.InputStreamUtils;
 import uk.bl.wa.util.Instrument;
 import uk.bl.wa.util.Normalisation;
 
@@ -150,10 +151,18 @@ public class HtmlFeatureParser extends AbstractParser {
      * 
      */
     @Override
-    public void parse(InputStream stream, ContentHandler handler,
+    public void parse(InputStream streamTemp, ContentHandler handler,
             Metadata metadata, ParseContext context) throws IOException,
             SAXException, TikaException {
+      InputStream stream= null;
         final long start = System.nanoTime();
+        try{
+           stream = InputStreamUtils.maybeDecompress(streamTemp);
+        }
+        catch(Exception e){
+          log.error("Error in automatic GZIP inputstream wrapper");
+          stream = streamTemp;          
+        }
         // Pick up the URL:
         String url = metadata.get( Metadata.RESOURCE_NAME_KEY );
         
@@ -307,4 +316,5 @@ public class HtmlFeatureParser extends AbstractParser {
         }
         return metadata;
     }
+  
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
@@ -1,0 +1,69 @@
+package uk.bl.wa.util;
+
+/*-
+ * #%L
+ * warc-indexer
+ * %%
+ * Copyright (C) 2013 - 2019 The webarchive-discovery project contributors
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import java.io.InputStream;
+import java.io.PushbackInputStream;
+import java.util.zip.GZIPInputStream;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+
+public class InputStreamUtils {
+
+  
+  private static Log log = LogFactory.getLog(InputStreamUtils.class );
+  
+  /*
+   * This method will detect if the inputstream is gzip and unzip the inputstream.
+   * If inputstream is not zippet, the same inputstream will be returned. 
+   *  
+   */
+  public static InputStream maybeDecompress(InputStream input) throws Exception {
+    final PushbackInputStream pb = new PushbackInputStream(input, 2);
+
+    int header = pb.read();
+    if(header == -1) {
+        return pb;
+    }
+
+    int b = pb.read();
+    if(b == -1) {
+        pb.unread(header);
+        return pb;
+    }
+
+    pb.unread(new byte[]{(byte)header, (byte)b});
+
+    header = (b << 8) | header;
+
+    if(header == GZIPInputStream.GZIP_MAGIC) {
+     log.debug("GZIP stream detected");  
+      return new GZIPInputStream(pb);
+    } else {
+        return pb;
+    }
+ }
+  
+}


### PR DESCRIPTION
@thomasegense made the code changes in this fix. I have only reviewed it and am doing the pull request logic. This pull requests closes #204 which means that WARCs from [Webrecorder](https://webrecorder.io/) should work with `webarchive-discovery`.