### PR TITLE
Add heuristic check for chunked content

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/WARCPayloadAnalysers.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/WARCPayloadAnalysers.java
@@ -91,10 +91,9 @@ public class WARCPayloadAnalysers {
 
         // Always run Tika first:
         // (this ensures the SOLR_CONTENT_TYPE is set)
-        final String compressionHint = httpHeader.getHeader("Content-Encoding", null);
         try {
-            tika.analyse(source, header, InputStreamUtils.maybeDecompress(tikainput, compressionHint), solr);
-        } catch (IOException e) {
+            tika.analyse(source, header, tikainput, solr);
+        } catch (Exception e) {
             log.error("IOException analyzing content of '" + source + "' with tika", e);
         }
 
@@ -106,7 +105,7 @@ public class WARCPayloadAnalysers {
                     // Reset input stream before running each parser:
                     tikainput.reset();
                     // Run the parser:
-                    provider.analyse(source, header, InputStreamUtils.maybeDecompress(tikainput, compressionHint), solr);
+                    provider.analyse(source, header, tikainput, solr);
                 } catch (Exception i) {
                     log.error(i + ": " + i.getMessage() + ";x; " + url + "@"
                             + header.getOffset(), i);

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -87,6 +87,7 @@ import uk.bl.wa.solr.SolrRecord;
 import uk.bl.wa.solr.SolrRecordFactory;
 import uk.bl.wa.solr.SolrWebServer;
 import uk.bl.wa.util.HashedCachedInputStream;
+import uk.bl.wa.util.InputStreamUtils;
 import uk.bl.wa.util.Instrument;
 import uk.bl.wa.util.Normalisation;
 
@@ -387,8 +388,12 @@ public class WARCIndexer {
                             httpHeader.getHeader("Transfer-Encoding", null))) {
                 // hcis = new HashedCachedInputStream(header, record,
                 // content_length);
-                hcis = new HashedCachedInputStream(header,
-                        new ChunkedInputStream(record), content_length,
+                // warcio and webrecorder does not agree on whether a chunked response should be stored raw,
+                // i.e. with all the chunked control structures, or de-chunked. The maybeDechunk makes a
+                // qualified guess and responds accordingly.
+                hcis = new HashedCachedInputStream(
+                        header,
+                        InputStreamUtils.maybeDechunk(record), content_length,
                         this.inMemoryThreshold, this.onDiskThreshold);
             } else {
                 // Otherwise, plain stream

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -42,14 +42,12 @@ import java.time.ZoneId;
 import java.util.*;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.httpclient.ChunkedInputStream;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpParser;
 import org.apache.commons.httpclient.ProtocolException;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpHeaders;
@@ -86,7 +84,6 @@ import uk.bl.wa.solr.SolrFields;
 import uk.bl.wa.solr.SolrRecord;
 import uk.bl.wa.solr.SolrRecordFactory;
 import uk.bl.wa.solr.SolrWebServer;
-import uk.bl.wa.util.HashedCachedInputStream;
 import uk.bl.wa.util.InputStreamUtils;
 import uk.bl.wa.util.Instrument;
 import uk.bl.wa.util.Normalisation;
@@ -381,43 +378,26 @@ public class WARCIndexer {
             
             // Create an appropriately cached version of the payload, to allow analysis.
             final long hashStreamStart = System.nanoTime();
-            // If it's a chunked encoding, wrap the input stream to decode:
-            final HashedCachedInputStream hcis;
-            if ("chunked"
-                    .equalsIgnoreCase(
-                            httpHeader.getHeader("Transfer-Encoding", null))) {
-                // hcis = new HashedCachedInputStream(header, record,
-                // content_length);
-                // warcio and webrecorder does not agree on whether a chunked response should be stored raw,
-                // i.e. with all the chunked control structures, or de-chunked. The maybeDechunk makes a
-                // qualified guess and responds accordingly.
-                hcis = new HashedCachedInputStream(
-                        header,
-                        InputStreamUtils.maybeDechunk(record), content_length,
-                        this.inMemoryThreshold, this.onDiskThreshold);
-            } else {
-                // Otherwise, plain stream
-                hcis = new HashedCachedInputStream(header, record,
-                        content_length, this.inMemoryThreshold,
-                        this.onDiskThreshold);
-            }
-            
+            final InputStreamUtils.HashIS hashIS = InputStreamUtils.cacheDecompressDechunkHash(
+                    record, content_length, targetUrl, header, httpHeader,
+                    this.inMemoryThreshold, this.onDiskThreshold);
+
             // If the hash didn't match, record it:
-            if (!hcis.isHashMatched()) {
+            if (!hashIS.getHashStream().isHashMatched()) {
                 // Facet-friendly:
                 solr.addField(SolrFields.PARSE_ERROR,
                         "Digest validation failed!");
                 // Detailed version:
                 solr.addField(SolrFields.PARSE_ERROR,
                         "Digest validation failed: header value is "
-                                + hcis.getHeaderHash()
+                                + hashIS.getHashStream().getHeaderHash()
                                 + " but calculated "
-                                + hcis.getHash());
+                                + hashIS.getHashStream().getHash());
             }
 
-            final InputStream tikaInput = hcis.getInputStream();
+            final InputStream tikaInput = hashIS.getInputStream();
             // TODO: Consider adding support for GZip / Brotli compression at this point
-            final String hash = hcis.getHash();
+            final String hash = hashIS.getHashStream().getHash();
             Instrument.timeRel("WARCIndexer.extract#total",
                                "WARCIndexer.extract#hashstreamwrap", hashStreamStart);
             // Set these last:
@@ -452,7 +432,7 @@ public class WARCIndexer {
             Instrument.timeRel("WARCIndexer.extract#total", "WARCIndexer.extract#analyzetikainput", analyzeStart);
 
             // Clear up the caching of the payload:
-            hcis.cleanup();
+            hashIS.cleanup();
 
             // -----------------------------------------------------
             // Payload analysis complete, now performing text analysis:

--- a/warc-indexer/src/main/java/uk/bl/wa/parsers/HtmlFeatureParser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/parsers/HtmlFeatureParser.java
@@ -151,19 +151,10 @@ public class HtmlFeatureParser extends AbstractParser {
      * 
      */
     @Override
-    public void parse(InputStream streamTemp, ContentHandler handler,
+    public void parse(InputStream stream, ContentHandler handler,
             Metadata metadata, ParseContext context) throws IOException,
             SAXException, TikaException {
-      InputStream stream= null;
         final long start = System.nanoTime();
-        try{
-            // TODO: Pass HTTP headers through to this point to provide compressionHint
-           stream = InputStreamUtils.maybeDecompress(streamTemp, null);
-        }
-        catch(Exception e){
-          log.error("Error in automatic GZIP inputstream wrapper");
-          stream = streamTemp;          
-        }
         // Pick up the URL:
         String url = metadata.get( Metadata.RESOURCE_NAME_KEY );
         

--- a/warc-indexer/src/main/java/uk/bl/wa/util/CachedInputStreamFactory.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/CachedInputStreamFactory.java
@@ -1,0 +1,155 @@
+/**
+ * 
+ */
+package uk.bl.wa.util;
+
+/*
+ * #%L
+ * warc-indexer
+ * %%
+ * Copyright (C) 2013 - 2020 The webarchive-discovery project contributors
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import org.apache.commons.codec.digest.MessageDigestAlgorithms;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.archive.format.warc.WARCConstants;
+import org.archive.io.ArchiveRecordHeader;
+import org.archive.util.Base32;
+import org.jwat.common.RandomAccessFileInputStream;
+
+import java.io.*;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_PAYLOAD_DIGEST;
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_TYPE;
+
+/**
+ * Utility method that takes a given input stream and caches the content in RAM, on disk, based on some size limits.
+ *
+ * This allows for cheap calls to {@link InputStream#reset()} from the input stream provided by {@link #getInputStream()}.
+ */
+public class CachedInputStreamFactory {
+    private static Log log = LogFactory.getLog( CachedInputStreamFactory.class );
+
+    // Thresholds:
+    public static final long defaultInMemoryThreshold = 1024*1024;     // Up to 1MB allowed in RAM.
+    public static final long defaultOnDiskThreshold =   1024*1024*100; // Up to 100MB cached on disk.
+
+    /**
+     * Reads length bytes from in to a memory- or disk-cache, depending on thresholds.
+     * Returns the cached bytes as an InputStream that supports {@link InputStream#mark(int)} up to length bytes.
+     *
+     * Note: It is important to call {@link InputStream#close()} after the returned InputStream has been used, to
+     * avoid temporary files building up.
+     *
+     * @param in any InputStream
+     * @param length the number of bytes to read from in.
+     * @param closeAfterRead if true, in will be closed after reading length bytes.
+     * @return an InputStream with the content of in  that supports {@link InputStream#mark(int)} up to length bytes.
+     */
+    public static InputStream cacheContent(InputStream in, long length, boolean closeAfterRead) {
+        return cacheContent(in, length, closeAfterRead, defaultInMemoryThreshold, defaultOnDiskThreshold);
+    }
+
+    /**
+     * Reads length bytes from in to a memory- or disk-cache, depending on thresholds.
+     * Returns the cached bytes as an InputStream that supports {@link InputStream#mark(int)} up to length bytes.
+     *
+     * Note: It is important to call {@link InputStream#close()} after the returned InputStream has been used, to
+     * avoid temporary files building up.
+     *
+     * @param in any InputStream
+     * @param length the number of bytes to read from in.
+     * @param closeAfterRead if true, in will be closed after reading length bytes.
+     * @param inMemoryThreshold if length is below this threshold, memory caching will be used, else disk caching will
+     *                          be used.
+     * @param onDiskThreshold if disk caching is used and length is above onDiskThresHold, only onDiskThreshold will be
+     *                        stored on disk, while the remainder will be discarded (it will still be read).
+     * @return an InputStream with the content of in  that supports {@link InputStream#mark(int)} up to length bytes.
+     */
+    public static InputStream cacheContent(InputStream in, long length, boolean closeAfterRead,
+                                           long inMemoryThreshold, long onDiskThreshold) {
+        try {
+            return length < inMemoryThreshold ?
+                    memoryCacheContent(in, (int) length, closeAfterRead) : // Always below 2GB
+                    diskCacheContent(in, length, closeAfterRead, onDiskThreshold);
+        } catch (IOException e) {
+            log.error("Unable to cache InputStream, returning empty stream", e);
+            return new ByteArrayInputStream(new byte[0]);
+        }
+    }
+
+    private static InputStream memoryCacheContent(
+            InputStream in, int length, boolean closeAfterRead) throws IOException {
+        ByteArrayOutputStream cache = new ByteArrayOutputStream(length);
+        IOUtils.copyLarge(in, cache, 0, length);
+        if (closeAfterRead) {
+            in.close();
+        }
+        return new ByteArrayInputStream(cache.toByteArray());
+    }
+
+    private static InputStream diskCacheContent(
+            InputStream in, long length, boolean closeAfterRead, long onDiskThreshold) throws IOException {
+        File cacheFile = File.createTempFile("warc-indexer", ".cache");
+        cacheFile.deleteOnExit();
+        OutputStream cache = new FileOutputStream(cacheFile);
+
+        long toCopy = Math.min(length, onDiskThreshold);
+        IOUtils.copyLarge(in, cache, 0, toCopy);
+        if (closeAfterRead) {
+            in.close();
+        }
+        cache.close();
+
+        boolean truncated = length > onDiskThreshold;
+        // Read the remainder of the stream
+        if(truncated) {
+            log.debug(String.format("diskCacheContent(length=%d, onDiskThreshold=%d) will be truncated",
+                                    length, onDiskThreshold));
+            // IOUtils.skip is not a skip: It reads the bytes from the stream, which is what we need
+            IOUtils.skip(in, length - onDiskThreshold);
+        }
+
+        return new RandomAccessFileInputStream(new RandomAccessFile(cacheFile, "r")) {
+            @Override
+            public void close() throws IOException {
+                super.close();
+                try {
+                    raf.close();
+                } catch (Exception e) {
+                    log.warn("Exception closing RandomAccessFile cache for '" + cacheFile + "'", e);
+                }
+                if(cacheFile.exists()) {
+                    try {
+                        if (!cacheFile.delete()) {
+                            log.warn("Unable to delete '" + cacheFile + "'");
+                        }
+                    } catch (Exception e) {
+                        log.warn("Exception deleting '" + cacheFile + "'", e);
+                    }
+                }
+
+            }
+        };
+    }
+}

--- a/warc-indexer/src/main/java/uk/bl/wa/util/HashedInputStream.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/HashedInputStream.java
@@ -1,0 +1,215 @@
+/**
+ *
+ */
+package uk.bl.wa.util;
+
+/*
+ * #%L
+ * warc-indexer
+ * %%
+ * Copyright (C) 2013 - 2020 The webarchive-discovery project contributors
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import org.apache.commons.codec.digest.MessageDigestAlgorithms;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.archive.format.warc.WARCConstants;
+import org.archive.io.ArchiveRecordHeader;
+import org.archive.util.Base32;
+import org.jwat.common.RandomAccessFileInputStream;
+
+import java.io.*;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_PAYLOAD_DIGEST;
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_TYPE;
+
+/**
+ * Utility method that takes a given input stream and wraps is in a SHA-1 {@link DigestInputStream}.
+ */
+public class HashedInputStream extends DigestInputStream {
+    private static Log log = LogFactory.getLog( HashedInputStream.class );
+
+
+    private final String url;
+    private final boolean checkHash;
+
+    private String headerHash = null;
+    private String hash = null;
+    private boolean hashMatched = false;
+    private boolean isClosed = false;
+    private boolean wasTruncated = false;
+    private long bytesLeft;
+
+    private static MessageDigest getDigester() {
+        try {
+            return MessageDigest.getInstance( MessageDigestAlgorithms.SHA_1);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Error: Algorithm '" + MessageDigestAlgorithms.SHA_1 + "' not supported", e);
+        }
+    }
+
+    /**
+     * Wraps the in stream in a SHA-1 calculating DigestStream, guaranteeing that at most length bytes are read from
+     * the in stream.
+     * @param header (w)arc header which ideally contain the expected hash.
+     * @param in a Stream with WARC record content.
+     * @param length the length of the record.
+     */
+    public HashedInputStream(ArchiveRecordHeader header, InputStream in, long length ) {
+        this(header.getUrl(),
+             header.getHeaderFieldKeys().contains(HEADER_KEY_PAYLOAD_DIGEST) ?
+                     (String) header.getHeaderValue(HEADER_KEY_PAYLOAD_DIGEST) :
+                     null,
+             header.getHeaderFieldKeys().contains(HEADER_KEY_TYPE) &&
+             header.getHeaderValue(HEADER_KEY_TYPE).equals(WARCConstants.WARCRecordType.response.toString()),
+             in,
+             length);
+    }
+
+    /**
+     * Wraps the in stream in a SHA-1 calculating DigestStream, guaranteeing that at most length bytes are read from
+     * the in stream.
+     * @param url the URL for the content. Used for log messages.
+     * @param expectedHash will be compared with the calculated hash.
+     * @param checkHash if true, the expectedHash will be compared with the calculated, if false the expectedHash
+     *                  will override the calculated.
+     * @param in a Stream with WARC record content.
+     * @param length the length of the record.
+     */
+    public HashedInputStream(String url, String expectedHash, boolean checkHash, InputStream in, long length ) {
+        super(in, getDigester());
+        bytesLeft = length;
+        this.url = Normalisation.sanitiseWARCHeaderValue(url);
+        this.headerHash = expectedHash;
+        this.checkHash = checkHash;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (bytesLeft == 0) {
+            return -1;
+        }
+        int b = super.read();
+        if (b == -1) {
+            bytesLeft = 0;
+            wasTruncated = true;
+        } else {
+            bytesLeft--;
+        }
+        return b;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (bytesLeft == 0) {
+            return -1;
+        }
+        if (len > bytesLeft) {
+            len = (int) bytesLeft;
+        }
+        int readBytes = super.read(b, off, len);
+        if (readBytes == -1) {
+            bytesLeft = 0;
+            wasTruncated = true;
+        } else {
+            bytesLeft -= readBytes;
+        }
+        return readBytes;
+    }
+
+    /**
+     * Ensures that all bytes up to the previously given length has been read from the source stream and closes it.
+     * Extracts the calculated hash and checks it against the header hash, writing an error to the log if there are
+     * a mismatch.
+     * @throws IOException if the source stream could not be closed.
+     */
+    @Override
+    public void close() throws IOException {
+        if (isClosed) {
+            return;
+        }
+        if (bytesLeft > 0) {
+            IOUtils.skip(this, bytesLeft);
+        }
+        isClosed = true;
+        super.close();
+
+        hash = "sha1:" + Base32.encode(digest.digest());
+        // For response records, check the hash is consistent with any header hash:
+        if ((headerHash == null) || (hash.length() != headerHash.length())) {
+            return;
+        }
+
+        if(checkHash) {
+            if(!headerHash.equals(hash)) {
+                log.warn(String.format(
+                        "Hashes are not equal for '%s'. WARC-header: %s, content: %s", url, headerHash, hash));
+                this.hashMatched = false;
+            } else {
+                log.debug("Hashes were found to match for '" + url + "'");
+                this.hashMatched = true;
+            }
+        } else {
+            // For revisit records, use the hash of the revisited payload:
+            // TODO this should actually only do it for revisit type records.
+            this.hash = this.headerHash;
+        }
+    }
+
+    public boolean isClosed() {
+        return isClosed;
+    }
+
+    /**
+     * @return true if the stream containes less bytes than expected.
+     */
+    public boolean wasTruncated() {
+        return wasTruncated;
+    }
+
+    /**
+     * @return true if the header hash matches the calculated hash.
+     */
+    public boolean isHashMatched() {
+        if (!isClosed) {
+            throw new IllegalStateException("Stream must be closed before calling isHashMatched()");
+        }
+        return hashMatched;
+    }
+
+    /**
+     * @return the calculated hash.
+     */
+    public String getHash() {
+        if (!isClosed) {
+            throw new IllegalStateException("Stream must be closed before calling getHash()");
+        }
+        return hash;
+    }
+
+    /**
+     * @return the header hash.
+     */
+    public String getHeaderHash() {
+        return headerHash;
+    }
+}

--- a/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
@@ -10,12 +10,12 @@ package uk.bl.wa.util;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -30,10 +30,94 @@ import java.util.zip.GZIPInputStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.archive.util.ArchiveUtils;
-
+import org.apache.commons.httpclient.ChunkedInputStream;
 
 public class InputStreamUtils {
     private static Log log = LogFactory.getLog(InputStreamUtils.class );
+
+    /**
+     * Checks if an input stream seems to be chunked. If so, the stream content is de-chunked.
+     * If not, the stream content is returned unmodified.
+     * Chunked streams must begin with {@code ^[0-9a-z]{1,8}(;.{0,1024})?\r\n}.
+     * @param input a stream with the response body from a HTTP-response.
+     * @return the un-chunked content of the given stream.
+     * @throws IOException if the stream could not be processed.
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding">Transfer-Encoding</a>
+     */
+    public static InputStream maybeDechunk(InputStream input) throws IOException {
+        final BufferedInputStream buf = new BufferedInputStream(input);
+        buf.mark(1024); // Room for a lot of comments
+        int pos = 0;
+        // Check for hex-number
+        while (pos < 8) {
+            int c = buf.read();
+            if (c== -1) { // EOF
+                log.debug("maybeDechunk reached EOF while looking for hex digits at pos " + pos + ": " +
+                          "Not a chunked stream, returning content as-is");
+                buf.reset();
+                return buf;
+            }
+            if (('0' <= c && c <= '9') || ('a' <= c && c <= 'f')) {
+                pos++;
+                continue;
+            }
+            break;
+        }
+        if (pos == 0 || pos == 8) {
+            log.debug("maybeDechunk found " + pos + " hex digits: Not a chunked stream, returning content as-is");
+            buf.reset();
+            return buf;
+        }
+        // Check for \r\n or extension
+        int c = buf.read();
+        if (c== -1) { // EOF
+            log.debug("maybeDechunk reached EOF while looking for extension or \\r\\n at pos " + pos + ": " +
+                      "Not a chunked stream, returning content as-is");
+            buf.reset();
+            return buf;
+        }
+        pos++;
+        if (c == ';') { // Extension
+            while (pos < 1024) {
+                while (pos < 1024 && c != '\r' && c != -1) { // Look for CR
+                    c = buf.read();
+                    pos++;
+                }
+                if (c == -1) {
+                    break;
+                }
+                c = buf.read();
+                pos++;
+                if (c == '\n' || c == -1) { // LF
+                    break;
+                }
+            }
+            if (pos == 1024 || c == -1) {
+                log.debug("maybeDechunk found hex digits and start of an extension but could not locate CRLF: " +
+                          "Not a chunked stream, returning content as-is");
+                buf.reset();
+                return buf;
+            }
+            log.debug("maybeDechunk found hex digits and an extension: Probably chunked stream, returning content " +
+                      "wrapped in a de-chunker");
+            buf.reset();
+            return new ChunkedInputStream(buf);
+        }
+        // Not with extension. Next chars must be CRLF
+        if (c == '\r') { // CR
+            c = buf.read();
+            if (c == '\n') { // LF
+                log.debug("maybeDechunk found hex digits CRLF: Probably chunked stream, returning content " +
+                          "wrapped in a de-chunker");
+                buf.reset();
+                return new ChunkedInputStream(buf);
+            }
+        }
+        log.debug("maybeDechunk found hex digits but could not locate CRLF: " +
+                  "Not a chunked stream, returning content as-is");
+        buf.reset();
+        return buf;
+    }
 
     /*
      * Provides a decompressing wrapper for the input. If the compressionHint is null, the method will attempt to
@@ -42,7 +126,7 @@ public class InputStreamUtils {
      * If the hint is empty, the input stream will be returned unmodified.
      * @param input the input stream that might be decompressed.
      * @param compressionHint if present, this will be used for selecting the compression scheme.
-      *       Usable values are 'GZip' and 'Br'. Not case-sensitive.
+     *       Usable values are 'GZip' and 'Br'. Not case-sensitive.
      */
     public static InputStream maybeDecompress(InputStream input, String compressionHint) throws IOException {
         final String hint = compressionHint == null ? null : compressionHint.toLowerCase().trim();

--- a/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
@@ -71,8 +71,8 @@ public class InputStreamUtils {
                 warcHeader.getHeaderValue(HEADER_KEY_TYPE).equals(WARCConstants.WARCRecordType.response.toString());
         String compressionHint = httpHeader == null ? null : httpHeader.getHeader("Content-Encoding", null);
         String chunkHint = httpHeader == null ? null : httpHeader.getHeader("Transfer-Encoding", null);
-        return cacheDecompressDechunkHash(input, length, url, expectedHash, checkHash, compressionHint, chunkHint,
-                                          inMemoryThreshold, onDiskThreshold);
+        return cacheDecompressDechunkHash(input, length, url, expectedHash, checkHash,
+                                          compressionHint, chunkHint, inMemoryThreshold, onDiskThreshold);
     }
 
     /**
@@ -80,6 +80,7 @@ public class InputStreamUtils {
      * returns the resulting content as a stream that supports {@link InputStream#mark(int)} up to length.
      * The hash digestion is performed directly on the bytes from input, before decompression & dechunking.
      * Dechunking is performed before decompression.
+     * Note: The final size of the content will normally exceed length if compression is used.
      * @param input any InputStream.
      * @param length the number of bytes to read from input.
      * @param url the URL for the content. Used for log messages.
@@ -99,13 +100,13 @@ public class InputStreamUtils {
      * @return a simple structure containing the hash information and the cached decompressed dechunked content.
      */
     public static HashIS cacheDecompressDechunkHash(
-            InputStream input, long length, String url, String expectedHash, boolean checkHash, String compressionHint, String chunkHint,
-            long inMemoryThreshold, long onDiskThreshold)
+            InputStream input, long length, String url, String expectedHash, boolean checkHash,
+            String compressionHint, String chunkHint, long inMemoryThreshold, long onDiskThreshold)
             throws IOException {
         HashedInputStream hash = new HashedInputStream(url, expectedHash, checkHash, input, length);
         InputStream stream = CachedInputStreamFactory.cacheContent(
                 maybeDecompress(maybeDechunk(hash, chunkHint), compressionHint),
-                length, true, inMemoryThreshold, onDiskThreshold);
+                length, false, true, inMemoryThreshold, onDiskThreshold);
         return new HashIS(stream, hash);
     }
 

--- a/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
@@ -48,9 +48,10 @@ public class InputStreamUtils {
         final BufferedInputStream buf = new BufferedInputStream(input);
         buf.mark(1024); // Room for a lot of comments
         int pos = 0;
+        int c = -1;
         // Check for hex-number
         while (pos < 8) {
-            int c = buf.read();
+            c = buf.read();
             if (c== -1) { // EOF
                 log.debug("maybeDechunk reached EOF while looking for hex digits at pos " + pos + ": " +
                           "Not a chunked stream, returning content as-is");
@@ -69,8 +70,7 @@ public class InputStreamUtils {
             return buf;
         }
         // Check for \r\n or extension
-        int c = buf.read();
-        if (c== -1) { // EOF
+        if (c == -1) { // EOF
             log.debug("maybeDechunk reached EOF while looking for extension or \\r\\n at pos " + pos + ": " +
                       "Not a chunked stream, returning content as-is");
             buf.reset();

--- a/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
@@ -29,23 +29,156 @@ import java.util.zip.GZIPInputStream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.archive.format.warc.WARCConstants;
+import org.archive.io.ArchiveRecord;
+import org.archive.io.ArchiveRecordHeader;
 import org.archive.util.ArchiveUtils;
 import org.apache.commons.httpclient.ChunkedInputStream;
+import uk.bl.wa.indexer.HTTPHeader;
+
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_PAYLOAD_DIGEST;
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_TYPE;
 
 public class InputStreamUtils {
     private static Log log = LogFactory.getLog(InputStreamUtils.class );
+
+
+    /**
+     * Calculates SHA-1 hash from length bytes of input, performs decompression & dechunking of the content and
+     * returns the resulting content as a stream that supports {@link InputStream#mark(int)} up to length.
+     * The hash digestion is performed directly on the bytes from input, before decompression & dechunking.
+     * Dechunking is performed before decompression.
+     * @param input any InputStream.
+     * @param length the number of bytes to read from input.
+     * @param url the URL for the content. Used for log messages.
+     * @param warcHeader will be used to derive expected hash.
+     * @param httpHeader will be used to extract hints for compression and chunking.
+     * @param inMemoryThreshold if length is below this threshold, memory caching will be used, else disk caching will
+     *                          be used.
+     * @param onDiskThreshold if disk caching is used and length is above onDiskThresHold, only onDiskThreshold will be
+     *                        stored on disk, while the remainder will be discarded (it will still be read).
+     * @return a simple structure containing the hash information and the cached decompressed dechunked content.
+     */
+    public static HashIS cacheDecompressDechunkHash(
+            InputStream input, long length, String url, ArchiveRecordHeader warcHeader,
+            HTTPHeader httpHeader, long inMemoryThreshold, long onDiskThreshold) throws IOException {
+        String expectedHash =
+                (warcHeader == null || !warcHeader.getHeaderFieldKeys().contains(HEADER_KEY_PAYLOAD_DIGEST))?
+                        null :
+                        (String) warcHeader.getHeaderValue(HEADER_KEY_PAYLOAD_DIGEST);
+        boolean checkHash =
+                warcHeader != null && warcHeader.getHeaderFieldKeys().contains(HEADER_KEY_TYPE) &&
+                warcHeader.getHeaderValue(HEADER_KEY_TYPE).equals(WARCConstants.WARCRecordType.response.toString());
+        String compressionHint = httpHeader == null ? null : httpHeader.getHeader("Content-Encoding", null);
+        String chunkHint = httpHeader == null ? null : httpHeader.getHeader("Transfer-Encoding", null);
+        return cacheDecompressDechunkHash(input, length, url, expectedHash, checkHash, compressionHint, chunkHint,
+                                          inMemoryThreshold, onDiskThreshold);
+    }
+
+    /**
+     * Calculates SHA-1 hash from length bytes of input, performs decompression & dechunking of the content and
+     * returns the resulting content as a stream that supports {@link InputStream#mark(int)} up to length.
+     * The hash digestion is performed directly on the bytes from input, before decompression & dechunking.
+     * Dechunking is performed before decompression.
+     * @param input any InputStream.
+     * @param length the number of bytes to read from input.
+     * @param url the URL for the content. Used for log messages.
+     * @param expectedHash will be compared with the calculated hash.
+     * @param checkHash if true, the expectedHash will be compared with the calculated, if false the expectedHash
+     *                  will override the calculated.
+     * @param compressionHint {@code brotli}, {@code gz} or null.
+     *                        Will be used with {@link #maybeDecompress(InputStream, String)}.
+     *                        Normally taken from the HTTP-header {@code Content-Encoding}.
+     * @param chunkHint       {@code chunked} or null.
+     *                        Will be used with {@link #maybeDechunk(InputStream, String)}.
+     *                        Normally taken from the HTTP-header {@code Transfer-Encoding}.
+     * @param inMemoryThreshold if length is below this threshold, memory caching will be used, else disk caching will
+     *                          be used.
+     * @param onDiskThreshold if disk caching is used and length is above onDiskThresHold, only onDiskThreshold will be
+     *                        stored on disk, while the remainder will be discarded (it will still be read).
+     * @return a simple structure containing the hash information and the cached decompressed dechunked content.
+     */
+    public static HashIS cacheDecompressDechunkHash(
+            InputStream input, long length, String url, String expectedHash, boolean checkHash, String compressionHint, String chunkHint,
+            long inMemoryThreshold, long onDiskThreshold)
+            throws IOException {
+        HashedInputStream hash = new HashedInputStream(url, expectedHash, checkHash, input, length);
+        InputStream stream = CachedInputStreamFactory.cacheContent(
+                maybeDecompress(maybeDechunk(hash, chunkHint), compressionHint),
+                length, true, inMemoryThreshold, onDiskThreshold);
+        return new HashIS(stream, hash);
+    }
+
+    /**
+     * Contains a hash for the content and an InputStream with the content that supports {@link InputStream#mark(int)}.
+     */
+    public static class HashIS {
+        private final InputStream is;
+        private final HashedInputStream hashStream;
+
+        public HashIS(InputStream is, HashedInputStream hashStream) {
+            this.is = is;
+            this.hashStream = hashStream;
+        }
+
+        /**
+         * @return an InputStream with the content that supports {@link InputStream#mark(int)}.
+         */
+        public InputStream getInputStream() {
+            return is;
+        }
+
+        /**
+         * @return a emptied and closed stream containing information on hashing.
+         */
+        public HashedInputStream getHashStream() {
+            return hashStream;
+        }
+
+        /**
+         * Closes the inner InputStream with the content.
+         * Important: This should be called after processing to avoid build up of temporary files.
+         */
+        public void cleanup() {
+            try {
+                is.close();
+            } catch (IOException e) {
+                log.warn("Exception closing inner InputStream. Probably not fatal as we are closing down", e);
+            }
+        }
+    }
+
+    /**
+     * If chunkHint is {@code "chunked"}, this will redurect to {@link #maybeDechunk(InputStream)}, else input
+     * will be returned unmodified.
+     * @param input a stream with the response body from a HTTP-response.
+     * @param chunkHint       {@code chunked} or null.
+     *                        Normally taken from the HTTP-header {@code Transfer-Encoding}.
+     * @return the un-chunked content of the given stream.
+     * @throws IOException if the stream could not be processed.
+     */
+    public static InputStream maybeDechunk(InputStream input, String chunkHint) throws IOException {
+        return "chunked".equalsIgnoreCase(chunkHint) ? maybeDechunk(input) : input;
+    }
 
     /**
      * Checks if an input stream seems to be chunked. If so, the stream content is de-chunked.
      * If not, the stream content is returned unmodified.
      * Chunked streams must begin with {@code ^[0-9a-z]{1,8}(;.{0,1024})?\r\n}.
+     * Note: Closing the returned stream will automatically close input.
      * @param input a stream with the response body from a HTTP-response.
      * @return the un-chunked content of the given stream.
      * @throws IOException if the stream could not be processed.
      * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding">Transfer-Encoding</a>
      */
     public static InputStream maybeDechunk(InputStream input) throws IOException {
-        final BufferedInputStream buf = new BufferedInputStream(input);
+        final BufferedInputStream buf = new BufferedInputStream(input) {
+            @Override
+            public void close() throws IOException {
+                super.close();
+                input.close();
+            }
+        };
         buf.mark(1024); // Room for a lot of comments
         int pos = 0;
         int c = -1;
@@ -101,7 +234,13 @@ public class InputStreamUtils {
             log.debug("maybeDechunk found hex digits and an extension: Probably chunked stream, returning content " +
                       "wrapped in a de-chunker");
             buf.reset();
-            return new ChunkedInputStream(buf);
+            return new ChunkedInputStream(buf) {
+                @Override
+                public void close() throws IOException {
+                    super.close();
+                    buf.close();
+                }
+            };
         }
         // Not with extension. Next chars must be CRLF
         if (c == '\r') { // CR
@@ -110,7 +249,13 @@ public class InputStreamUtils {
                 log.debug("maybeDechunk found hex digits CRLF: Probably chunked stream, returning content " +
                           "wrapped in a de-chunker");
                 buf.reset();
-                return new ChunkedInputStream(buf);
+                return new ChunkedInputStream(buf) {
+                    @Override
+                    public void close() throws IOException {
+                        super.close();
+                        buf.close();
+                    }
+                };
             }
         }
         log.debug("maybeDechunk found hex digits but could not locate CRLF: " +
@@ -124,6 +269,7 @@ public class InputStreamUtils {
      * auto-guess if the input is GZip-compressed. Auto-guessing does not work for Brotli as such detection is
      * unreliable for that format.
      * If the hint is empty, the input stream will be returned unmodified.
+     * Note: Closing the returned stream will automatically close input.
      * @param input the input stream that might be decompressed.
      * @param compressionHint if present, this will be used for selecting the compression scheme.
      *       Usable values are 'GZip' and 'Br'. Not case-sensitive.
@@ -132,20 +278,45 @@ public class InputStreamUtils {
         final String hint = compressionHint == null ? null : compressionHint.toLowerCase().trim();
         if (hint == null) { // Auto-guess
             // Detecting Brotli is hard: https://stackoverflow.com/questions/39008957/is-there-a-way-to-check-if-a-buffer-is-in-brotli-compressed-format
-            final BufferedInputStream buf = new BufferedInputStream(input);
-            buf.mark(1024);
-            if (ArchiveUtils.isGzipped(buf)) {
+            final BufferedInputStream buffer = new BufferedInputStream(input) {
+                @Override
+                public void close() throws IOException {
+                    super.close();
+                    input.close();
+                }
+            };
+            buffer.mark(1024);
+            if (ArchiveUtils.isGzipped(buffer)) {
                 log.debug("GZIP stream auto detected");
-                buf.reset();
-                return new GZIPInputStream(buf);
+                buffer.reset();
+                return new GZIPInputStream(buffer) {
+                    @Override
+                    public void close() throws IOException {
+                        super.close();
+                        buffer.close();
+                    }
+                };
             }
-            buf.reset();
-            return buf;
+            buffer.reset();
+            return buffer;
         }
+
         switch (hint) {
             case "": return input;
-            case "gzip": return new GZIPInputStream(input);
-            case "br": return new org.brotli.dec.BrotliInputStream(input);
+            case "gzip": return new GZIPInputStream(input) {
+                @Override
+                public void close() throws IOException {
+                    super.close();
+                    input.close();
+                }
+            };
+            case "br": return new org.brotli.dec.BrotliInputStream(input) {
+                @Override
+                public void close() throws IOException {
+                    super.close();
+                    input.close();
+                }
+            };
             default: {
                 log.warn("Unsupported compression hint '" + compressionHint + "'. Returning stream as-is");
                 return input;

--- a/warc-indexer/src/test/java/uk/bl/wa/indexer/WARCIndexerTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/indexer/WARCIndexerTest.java
@@ -37,8 +37,9 @@ import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
-import org.apache.commons.fileupload.util.Streams;
 import org.apache.commons.httpclient.*;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.archive.io.ArchiveReader;
 import org.archive.io.ArchiveReaderFactory;
 import org.archive.io.ArchiveRecord;
@@ -58,6 +59,7 @@ import uk.bl.wa.solr.SolrRecord;
 import uk.bl.wa.solr.SolrRecordFactory;
 
 public class WARCIndexerTest {
+    private static Log log = LogFactory.getLog(WARCIndexerTest.class);
 
     /**
      * Check timestamp parsing is working correctly, as various forms exist in the ARCs and WARCs.
@@ -269,6 +271,7 @@ public class WARCIndexerTest {
                     continue;
                 }
                 assertTrue("The record in '" + warc + "'should be a WARC-record", rec instanceof WARCRecord);
+                log.info("WARC:" + warc + " url:" + rec.getHeader().getUrl());
 
                 SolrRecord doc = windex.extract("", rec);
                 assertTrue("The field '" + SolrFields.SOLR_EXTRACTED_TEXT + "' should be present in the" +
@@ -278,7 +281,7 @@ public class WARCIndexerTest {
                 if (!content.contains(EXPECTED_CONTENT)) {
                     Assert.fail("The response in " + warc + "" +
                                 " did not contain the expected phrase \"" + EXPECTED_CONTENT +
-                                "\". This indicates that it was compressed in an unsupported way.");
+                                "\". This indicates that it was compressed in an unsupported way.\n\n" + content);
                 }
             }
         }


### PR DESCRIPTION
This pull request addresses the problem with webrecorder chunked content, as described in [issue 218](https://github.com/ukwa/webarchive-discovery/issues/218), by checking to see if the beginning of the possibly chunked content fits the chunked content standard (hex digits).