### PR TITLE
Decompress and dechunk fixes

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -121,6 +121,7 @@ public class WARCIndexer {
     /** Payload Analysers */
     private long inMemoryThreshold;
     private long onDiskThreshold;
+    private final InputStreamUtils.HASH_STAGE hashStage;
     private WARCPayloadAnalysers wpa;
     
     /** Text Analysers */
@@ -210,7 +211,11 @@ public class WARCIndexer {
         // Set up hash-cache properties:
         this.inMemoryThreshold = conf.getBytes( "warc.index.extract.inMemoryThreshold" );
         this.onDiskThreshold = conf.getBytes( "warc.index.extract.onDiskThreshold" );
-        log.info("Hashing & Caching thresholds are: < "+this.inMemoryThreshold+" in memory, < "+this.onDiskThreshold+" on disk.");
+        this.hashStage = conf.hasPath("warc.index.extract.hashStage") ?
+                InputStreamUtils.HASH_STAGE.valueOf(conf.getString("warc.index.extract.hashStage")) :
+                InputStreamUtils.DEFAULT_HASH_STAGE;
+        log.info("Hashing & Caching thresholds are: < "+this.inMemoryThreshold+" in memory, < "+
+                 this.onDiskThreshold+" on disk. HashStage = " + this.hashStage);
         
         // Set up analysers
         log.info("Setting up analysers...");
@@ -380,7 +385,7 @@ public class WARCIndexer {
             final long hashStreamStart = System.nanoTime();
             final InputStreamUtils.HashIS hashIS = InputStreamUtils.cacheDecompressDechunkHash(
                     record, content_length, targetUrl, header, httpHeader,
-                    this.inMemoryThreshold, this.onDiskThreshold);
+                    this.inMemoryThreshold, this.onDiskThreshold, this.hashStage);
 
             // If the hash didn't match, record it:
             if (!hashIS.getHashStream().isHashMatched()) {

--- a/warc-indexer/src/main/java/uk/bl/wa/util/HashedCachedInputStream.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/HashedCachedInputStream.java
@@ -123,7 +123,7 @@ public class HashedCachedInputStream {
         
         try {
             if( header.getHeaderFieldKeys().contains( HEADER_KEY_PAYLOAD_DIGEST ) ) {
-                headerHash = ( String ) header.getHeaderValue( HEADER_KEY_PAYLOAD_DIGEST );
+                headerHash = Normalisation.sha1HashAsBase32((String) header.getHeaderValue(HEADER_KEY_PAYLOAD_DIGEST));
             }
             
             // Create a suitable outputstream for caching the content:

--- a/warc-indexer/src/main/java/uk/bl/wa/util/HashedInputStream.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/HashedInputStream.java
@@ -13,12 +13,12 @@ package uk.bl.wa.util;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.

--- a/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
@@ -48,9 +48,10 @@ public class InputStreamUtils {
     public static final boolean LENIENT_DECHUNK = true;
 
     /**
-     * If no explicit hashStage is stated, this will be used.
+     * If no explicit hashStage is stated, this will be used. This stage matches the warc-1.1 specification
+     * http://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.1/#warc-payload-digest
      */
-    public static final HASH_STAGE DEFAULT_HASH_STAGE = HASH_STAGE.first;
+    public static final HASH_STAGE DEFAULT_HASH_STAGE = HASH_STAGE.after_dechunk_before_decompression;
 
     /**
      * The WARC standard at https://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.1/#warc-payload-digest
@@ -78,7 +79,7 @@ public class InputStreamUtils {
      * Calculates SHA-1 hash from length bytes of input, performs decompression & dechunking of the content and
      * returns the resulting content as a stream that supports {@link InputStream#mark(int)} up to length.
      * The hash digestion is performed directly on the bytes from input, before decompression & dechunking.
-     * Dechunking is performed before decompression. Hashing is done first (before dechunking and decompression)
+     * Dechunking is performed before decompression. Hashing is done after dechunking but before decompression
      * as per {@link #DEFAULT_HASH_STAGE}.
      * @param input any InputStream.
      * @param length the number of bytes to read from input.
@@ -101,7 +102,6 @@ public class InputStreamUtils {
     /**
      * Calculates SHA-1 hash from length bytes of input, performs decompression & dechunking of the content and
      * returns the resulting content as a stream that supports {@link InputStream#mark(int)} up to length.
-     * The hash digestion is performed directly on the bytes from input, before decompression & dechunking.
      * Dechunking is performed before decompression.
      * @param input any InputStream.
      * @param length the number of bytes to read from input.
@@ -135,7 +135,6 @@ public class InputStreamUtils {
     /**
      * Calculates SHA-1 hash from length bytes of input, performs decompression & dechunking of the content and
      * returns the resulting content as a stream that supports {@link InputStream#mark(int)} up to length.
-     * The hash digestion is performed directly on the bytes from input, before decompression & dechunking.
      * Dechunking is performed before decompression.
      * Note: The final size of the content will normally exceed length if compression is used.
      * @param input any InputStream.

--- a/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
@@ -10,12 +10,12 @@ package uk.bl.wa.util;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -105,7 +105,8 @@ public class InputStreamUtils {
             throws IOException {
         HashedInputStream hash = new HashedInputStream(url, expectedHash, checkHash, input, length);
         InputStream stream = CachedInputStreamFactory.cacheContent(
-                maybeDecompress(maybeDechunk(hash, chunkHint), compressionHint),
+                // Don't try to de-chunk or de-compress if length is 0
+                length == 0 ? hash : maybeDecompress(maybeDechunk(hash, chunkHint), compressionHint),
                 length, false, true, inMemoryThreshold, onDiskThreshold);
         return new HashIS(stream, hash);
     }

--- a/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
@@ -226,7 +226,7 @@ public class InputStreamUtils {
                 buf.reset();
                 return buf;
             }
-            if (('0' <= c && c <= '9') || ('a' <= c && c <= 'f')) {
+            if (('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F')) {
                 pos++;
                 continue;
             }

--- a/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/InputStreamUtils.java
@@ -71,6 +71,7 @@ public class InputStreamUtils {
                 warcHeader.getHeaderValue(HEADER_KEY_TYPE).equals(WARCConstants.WARCRecordType.response.toString());
         String compressionHint = httpHeader == null ? null : httpHeader.getHeader("Content-Encoding", null);
         String chunkHint = httpHeader == null ? null : httpHeader.getHeader("Transfer-Encoding", null);
+        log.info("length=" + length + ", hint=" + compressionHint + ", date=" + (warcHeader != null ? warcHeader.getDate() : "n/a"));
         return cacheDecompressDechunkHash(input, length, url, expectedHash, checkHash,
                                           compressionHint, chunkHint, inMemoryThreshold, onDiskThreshold);
     }

--- a/warc-indexer/src/main/resources/reference.conf
+++ b/warc-indexer/src/main/resources/reference.conf
@@ -9,6 +9,12 @@
                 "inMemoryThreshold" : 50M,
                 # Maximum payload size that will be serialised out to disk instead of held in RAM:
                 "onDiskThreshold" : 1000M,
+                # Where in the delivery chain hashing/digest is performed. Valid values are
+                # first: The hashing will be calculated over the WARC-payload bytes as-is.
+                # after_dechunk_before_decompression: The hashing will be calculated after dechunking, but before decompression.
+                # after_dechunk_after_decompression: The hashing will be calculated after dechunking and after decompression.
+                # If no hashStage is defined in the config, the default "first" will be used.
+                "hashStage" : "first",
                 
                 # Content to extract
                 "content" : {

--- a/warc-indexer/src/main/resources/reference.conf
+++ b/warc-indexer/src/main/resources/reference.conf
@@ -13,8 +13,8 @@
                 # first: The hashing will be calculated over the WARC-payload bytes as-is.
                 # after_dechunk_before_decompression: The hashing will be calculated after dechunking, but before decompression.
                 # after_dechunk_after_decompression: The hashing will be calculated after dechunking and after decompression.
-                # If no hashStage is defined in the config, the default "first" will be used.
-                "hashStage" : "first",
+                # If no hashStage is defined in the config, the default "after_dechunk_before_decompression" will be used.
+                "hashStage" : "after_dechunk_before_decompression",
                 
                 # Content to extract
                 "content" : {

--- a/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/util/NormalisationTest.java
@@ -236,4 +236,11 @@ public class NormalisationTest {
                          test[1], Normalisation.canonicaliseHost(test[0]));
         }
     }
+
+    @Test
+    public void testBase16ToBytes() {
+        final String B16 = "sha1:5a3311bde611032119d6080eebf83a4a3b3475ed";
+        final String B32 = "sha1:LIZRDPPGCEBSCGOWBAHOX6B2JI5TI5PN";
+        assertEquals(B32, Normalisation.sha1HashAsBase32(B16));
+    }
 }


### PR DESCRIPTION
A WARC constructed by warcproxy (sorry, cannot be shared) demonstrated some bugs in the decompression and dechunking handling in `InputStreamUtils`, which this pull request fixes:

 * An error was logged when 0-length content was marked as `gzip` (happens legally with revisits)
 * Chunk-detection did not handle chunk markers with 8 hex-digits, only 1-7
 * Chunk-detection did not handle uppercase hex digits
 * Problems in chunk-detection did not log anything to identify the offending record (now it logs the URL)

The problems with dechunking were masked by the decompression step, as the errors logged were from the decompressor complaining about illegal input.

Furthermore this pull request fixes #233 #234  (partially) and #235 which are all problems with the hash values from digest intertwined with the dechunk/decompress-code.