### PR TITLE
Fix code for getting geo coordinates from images

### DIFF
--- a/warc-indexer/src/test/java/uk/bl/wa/indexer/WARCIndexerCommandTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/indexer/WARCIndexerCommandTest.java
@@ -35,19 +35,8 @@ import java.security.NoSuchAlgorithmException;
 
 import static org.junit.Assert.*;
 
-/*
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+/**
+ * Helper class for debugging warc-indexer with local canfigs & WARCs.
  */
 public class WARCIndexerCommandTest {
     private static Log log = LogFactory.getLog(WARCIndexerCommandTest.class);
@@ -57,6 +46,14 @@ public class WARCIndexerCommandTest {
     public void testSBWARC() throws NoSuchAlgorithmException, TransformerException, IOException {
         testWARC("/home/te/projects/measurements/solrcloud/config3.conf",
                 "/home/te/projects/measurements/solrcloud/169568-178-20121224135757-00257-sb-prod-har-006.statsbiblioteket.dk.arc.gz");
+        Instrument.log(true);
+    }
+
+    // Local WARC that contains EXIF which was not indexed
+    @Test
+    public void testKBWARCExif() throws NoSuchAlgorithmException, TransformerException, IOException {
+        testWARC("/home/te/projects/webarchive-discovery/config3_toes.conf",
+                "/home/te/projects/webarchive-discovery/katte_gps.warc");
         Instrument.log(true);
     }
 


### PR DESCRIPTION
Apparently the Tika upgrade caused the keys for EXIF information in images to be changed. This again meant that geo coordinates were not extracted from images.

This pull-request adds checks for `GPS Latitude` (the old key), `GPS:GPS Latitude` (new key) and `geo:lat` (new key? With easier floating-point coordinate format). And of course the equivalent for longitude.