### PR TITLE
Add support for indexing srcset links as image links

### DIFF
--- a/warc-indexer/src/test/java/uk/bl/wa/analyser/payload/HTMLAnalyserTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/analyser/payload/HTMLAnalyserTest.java
@@ -66,7 +66,7 @@ public class HTMLAnalyserTest {
         Config config = ConfigFactory.parseFile(CONF);
         HTMLAnalyser ha = new HTMLAnalyser(config);
         Map<String, Object> core = new HashMap<String, Object>();
-        core.put("subject-uri", "NotPresent");
+        core.put("subject-uri", "http://example.org/");
         core.put("ip-address", "192.168.1.10");
         core.put("creation-date", "Invalid");
         core.put("content-type", "text/html");
@@ -81,12 +81,12 @@ public class HTMLAnalyserTest {
         ha.analyse("source", header, in, solr);
 
         // Check number of links:
-        assertEquals("The number of links should be correct", 4,
+        assertEquals("The number of links should be correct", 6,
                 solr.getField(SolrFields.SOLR_LINKS).getValueCount());
 
         // Check hosts are canonicalized:
-        assertEquals("The number of hosts should be correct", 1,
-                solr.getField(SolrFields.SOLR_LINKS_HOSTS).getValueCount());
+        assertEquals("The number of hosts should be correct. Got hosts " + solr.getField(SolrFields.SOLR_LINKS_HOSTS),
+                     1, solr.getField(SolrFields.SOLR_LINKS_HOSTS).getValueCount());
         String host = (String) solr.getField(SolrFields.SOLR_LINKS_HOSTS)
                 .getFirstValue();
         assertEquals("The host should be formatted correctly", "example.org",
@@ -107,5 +107,7 @@ public class HTMLAnalyserTest {
                 solr.getField(SolrFields.SOLR_LINKS_HOSTS_SURTS).getValues()
                         .toArray());
 
+        assertEquals("Image links should be for both src and srcset",
+                     12, solr.getField(SolrFields.SOLR_LINKS_IMAGES).getValueCount());
     }
 }

--- a/warc-indexer/src/test/resources/links_extract.html
+++ b/warc-indexer/src/test/resources/links_extract.html
@@ -2,7 +2,7 @@
 <head>
     <title>Page for link extraction checking</title>
 </head>
-<body>
+<body background="mybackground.jpg"> <!-- HTML 4 style -->
 <h1>See HTMLAnalyserTest for test code</h1>
 <p>
     <ul>
@@ -16,5 +16,16 @@
     </ul>
 
 </p>
+<p><img src="http://example.org/fooA.png" srcset="http://example.org/foo1.png 1.5x, http://example.org/foo2.png 2x" /></p>
+<p><img src="fooB.png" srcset="foo3.png 720w, http://example.org/foo4.png 1080w" /></p>
+<p><img src="http://example.org/fooD.png" srcset="http://example.org/foo5.png" /></p> <!-- Yes, invalid, but this is The Internet! -->
+
+<!--  https://www.w3schools.com/TAgs/att_source_srcset.asp -->
+  <picture>
+  <source media="(min-width:650px)" srcset="http://example.org/fooC1.png">
+  <source media="(min-width:465px)" srcset="http://example.org/fooC2.png">
+  <img src="http://example.org/fooC0.png" alt="Flowers" style="width:auto;">
+</picture>
+
 </body>
 </html>


### PR DESCRIPTION
This pull request adds support for [srcSet](https://webdesign.tutsplus.com/tutorials/quick-tip-how-to-use-html5-picture-for-responsive-images--cms-21015
) in `img` and `picture`, meaning that links from there will be added to the `links_images`-field in the SolrDocument.

This closes #246 
