### PR TITLE
Field rewrite

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -286,7 +286,7 @@ public class WARCIndexerCommand {
         if(solrUrl != null) {
             conf = conf.withValue(SolrWebServer.CONF_HTTP_SERVER, ConfigValueFactory.fromAnyRef(solrUrl) );
         }
-        
+
         ElasticImporter elasticImporter = null;
         if(elasticUrl != null) {
         	ElasticUrl eu = new ElasticUrl(elasticUrl);

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/FieldAdjuster.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/FieldAdjuster.java
@@ -23,12 +23,18 @@ import java.util.function.UnaryOperator;
 public class FieldAdjuster implements UnaryOperator<String> {
     private final int maxValues;
     private final Function<String, String> inner;
+    private final String pipeline;
 
     public static final FieldAdjuster PASSTHROUGH = new FieldAdjuster(-1, s -> s);
 
     public FieldAdjuster(int maxValues, Function<String, String> inner) {
+        this(maxValues, inner, "N/A");
+    }
+
+    public FieldAdjuster(int maxValues, Function<String, String> inner, String pipelineDescription) {
         this.maxValues = maxValues;
         this.inner = inner;
+        this.pipeline = pipelineDescription;
     }
 
     @Override
@@ -47,6 +53,7 @@ public class FieldAdjuster implements UnaryOperator<String> {
     public String toString() {
         return "FieldAdjuster{" +
                "maxValues=" + maxValues +
-               '}';
+               ", pipeline=[" + pipeline +
+               "]}";
     }
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/FieldAdjuster.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/FieldAdjuster.java
@@ -1,0 +1,52 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package uk.bl.wa.solr;
+
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+/**
+ * Field content adjuster used by {@link SolrRecord}.
+ */
+public class FieldAdjuster implements UnaryOperator<String> {
+    private final int maxValues;
+    private final Function<String, String> inner;
+
+    public static final FieldAdjuster PASSTHROUGH = new FieldAdjuster(-1, s -> s);
+
+    public FieldAdjuster(int maxValues, Function<String, String> inner) {
+        this.maxValues = maxValues;
+        this.inner = inner;
+    }
+
+    @Override
+    public String apply(String s) {
+        return maxValues == 0 ? null : inner.apply(s);
+    }
+
+    /**
+     * @return the maximum allowed valued for the given field.
+     */
+    public int getMaxValues() {
+        return maxValues;
+    }
+
+    @Override
+    public String toString() {
+        return "FieldAdjuster{" +
+               "maxValues=" + maxValues +
+               '}';
+    }
+}

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecord.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecord.java
@@ -30,27 +30,14 @@ package uk.bl.wa.solr;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.Writer;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CharsetEncoder;
-import java.nio.charset.CodingErrorAction;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
+import java.util.*;
+import java.util.function.UnaryOperator;
 
 import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
 import org.archive.io.ArchiveRecordHeader;
 
-import uk.bl.wa.util.Instrument;
 import uk.bl.wa.util.Normalisation;
 
 /**
@@ -61,16 +48,23 @@ public class SolrRecord implements Serializable {
 
     // private static Logger log = LoggerFactory.getLogger(SolrRecord.class);
 
-    private static final long serialVersionUID = -4556484652176976472L;
+    private static final long serialVersionUID = -4556484652176976473L;
     
     private SolrInputDocument doc = new SolrInputDocument();
 
-    private final int defaultMax;
-    private final HashMap<String, Integer> maxLengths; // Explicit HashMap as it is Serializable
+    /**
+     * field name -> function map for adjusting content length, correct UTF-8 problems etc.
+     */
+    private final Map<String, FieldAdjuster> contentAdjusters;
+    /**
+     * If there is no contentAdjuster available for a given field from {@link #contentAdjusters},
+     * the defaultContentAdjuster is used.
+     */
+    private final FieldAdjuster defaultContentAdjuster;
 
-    public SolrRecord(int defaultMaxFieldLength, HashMap<String, Integer> maxFieldLengths) {
-        this.defaultMax = defaultMaxFieldLength;
-        this.maxLengths = maxFieldLengths;
+    public SolrRecord(Map<String, FieldAdjuster> contentAdjusters, FieldAdjuster defaultcontentAdjuster) {
+        this.contentAdjusters = contentAdjusters;
+        this.defaultContentAdjuster = defaultcontentAdjuster == null ? FieldAdjuster.PASSTHROUGH : defaultcontentAdjuster;
     }
 
     /**
@@ -78,7 +72,35 @@ public class SolrRecord implements Serializable {
      */
     @Deprecated
     public SolrRecord() {
-        this(SolrRecordFactory.DEFAULT_MAX_LENGTH, new HashMap<String, Integer>());
+        this(Collections.emptyMap(), getDefaultMaxLengthAdjuster());
+    }
+
+    public SolrRecord(Map<String, FieldAdjuster> contentAdjusters, FieldAdjuster defaultContentAdjuster,
+                      String filename, ArchiveRecordHeader header) {
+        this(contentAdjusters, defaultContentAdjuster);
+        setField(SolrFields.ID, "exception-at-" + filename + "@" + header.getOffset());
+        setField(SolrFields.SOURCE_FILE, filename);
+        setField(SolrFields.SOURCE_FILE_OFFSET, "" + header.getOffset());
+        setField(SolrFields.SOLR_URL, Normalisation.sanitiseWARCHeaderValue(header.getUrl()));
+        setField(SolrFields.SOLR_URL_TYPE, SolrFields.SOLR_URL_TYPE_UNKNOWN);
+    }
+
+    /**
+     * @deprecated use {@link SolrRecordFactory#createRecord(String, ArchiveRecordHeader)} instead.
+     */
+    public SolrRecord(String filename, ArchiveRecordHeader header) {
+        this(Collections.emptyMap(), getDefaultMaxLengthAdjuster(), filename, header);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    private static FieldAdjuster getDefaultMaxLengthAdjuster() {
+        return new FieldAdjuster(
+                -1,
+                s -> SolrRecordFactory.DEFAULT_MAX_LENGTH < 0 || s == null ||
+                     s.length() < SolrRecordFactory.DEFAULT_MAX_LENGTH ?
+                        s :
+                        s.substring(0, SolrRecordFactory.DEFAULT_MAX_LENGTH)
+        );
     }
 
     public String toXml() {
@@ -93,101 +115,6 @@ public class SolrRecord implements Serializable {
         ClientUtils.writeXML( doc, writer );
     }
 
-    public SolrRecord(int defaultMaxFieldLength, HashMap<String, Integer> maxFieldLengths,
-                      String filename, ArchiveRecordHeader header) {
-        defaultMax = defaultMaxFieldLength;
-        maxLengths = maxFieldLengths;
-        setField(SolrFields.ID,
-                "exception-at-" + filename + "@" + header.getOffset());
-        setField(SolrFields.SOURCE_FILE, filename);
-        setField(SolrFields.SOURCE_FILE_OFFSET, "" + header.getOffset());
-        setField(SolrFields.SOLR_URL, Normalisation.sanitiseWARCHeaderValue(header.getUrl()));
-        setField(SolrFields.SOLR_URL_TYPE, SolrFields.SOLR_URL_TYPE_UNKNOWN);
-    }
-
-    /**
-     * @deprecated use {@link SolrRecordFactory#createRecord(String, ArchiveRecordHeader)} instead.
-     */
-    public SolrRecord(String filename, ArchiveRecordHeader header) {
-        this(SolrRecordFactory.DEFAULT_MAX_LENGTH, new HashMap<String, Integer>(), filename, header);
-    }
-
-    /**
-     * Remove control characters, nulls etc,
-     * 
-     * @param value
-     * @return
-     */
-    private String removeControlCharacters( String value ) {
-        final long start = System.nanoTime();
-        try {
-            // Avoid re-compiling the regexps in each call (just a small speed-up, but a simple one)
-            return CNTRL_PATTERN.matcher(
-                    SPACE_PATTERN.matcher(sanitiseUTF8(value.trim())).replaceAll(" ")
-            ).replaceAll("");
-//            return sanitiseUTF8(value.trim().replaceAll("\\p{Space}", " ")
-//                             .replaceAll("\\p{Cntrl}", ""));
-        } catch (CharacterCodingException e) {
-            return "";
-        } finally {
-            Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#solrdocCreation",
-                               "SolrRecord.removeControlCharacters#total", start);
-        }
-    }
-    private static final Pattern SPACE_PATTERN = Pattern.compile("\\p{Space}");
-    private static final Pattern CNTRL_PATTERN = Pattern.compile("\\p{Cntrl}");
-
-    /**
-     * Aim to prevent "Invalid UTF-8 character 0xfffe" slipping into the text
-     * payload.
-     * 
-     * The encodes and decodes a String that may not be UTF-8 compliant as
-     * UTF-8. Any dodgy characters are replaced.
-     * 
-     * @param value
-     * @return
-     * @throws CharacterCodingException
-     */
-    // It would be nice to re-use the encoder & decoder, but they are not Thread-safe
-    private CharSequence sanitiseUTF8(String value) throws CharacterCodingException {
-        final long start = System.nanoTime();
-        try  {
-            // Take a string, map it to bytes as UTF-8:
-            CharsetEncoder encoder = Charset.forName("UTF-8").newEncoder();
-            encoder.onMalformedInput(CodingErrorAction.REPLACE);
-            encoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
-            ByteBuffer bytes = encoder.encode(CharBuffer.wrap(value));
-            // Now decode back again:
-            CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder();
-            decoder.onMalformedInput(CodingErrorAction.REPLACE);
-            decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
-            // No need to do toString as the CharBuffer can be used directly by the matcher in removeControlCharacters
-            return decoder.decode(bytes);
-        } finally {
-            Instrument.timeRel("SolrRecord.removeControlCharacters#total", "SolrRecord.sanitiseUTF8", start);
-        }
-    }
-
-
-    /**
-     * Also shorten to avoid bad data filling 'small' fields with 'big' data.
-     * 
-     * @param value
-     * @param truncateToLength to truncate to (-1 means don't truncate)
-     * @return
-     */
-    private String sanitizeString(String value, int truncateToLength) {
-        if (value == null) {
-            return null;
-        }
-        if (truncateToLength > 0) {
-            if (value.length() > truncateToLength) {
-                value = value.substring(0, truncateToLength);
-            }
-        }
-        return removeControlCharacters(value);
-    }
-
     /**
      * Add any non-null string properties, stripping control characters if present.
      * 
@@ -195,12 +122,10 @@ public class SolrRecord implements Serializable {
      * @param value
      */
     public void addField(String solr_property, String value) {
-        addFieldTruncated(solr_property, value, getMaxLength(solr_property));
-    }
-
-    private int getMaxLength(String solrField) {
-        Integer max = maxLengths.get(solrField);
-        return max == null ? defaultMax : max;
+        String adjusted = adjust(solr_property, value);
+        if (adjusted != null && isAllowedtoAdd(solr_property, adjusted)) {
+            doc.addField(solr_property, adjusted);
+        }
     }
 
     /**
@@ -208,18 +133,11 @@ public class SolrRecord implements Serializable {
      * 
      * @param solr_property
      * @param value
-     * @param truncateTo
+     * @param truncateTo ignored after deprecation.
+     * @deprecated superceeded by the {@link #contentAdjusters} mechanism. Use {@link #addField(String, String)} instead.
      */
     public void addFieldTruncated(String solr_property, String value, int truncateTo) {
-        value = sanitizeString(value, truncateTo);
-        // If the value is not empty:
-        if (value != null && !value.isEmpty()) {
-            // Check if the value is already set:
-            Collection<Object> values = doc.getFieldValues(solr_property);
-            if (values == null || !values.contains(value)) {
-                doc.addField(solr_property, value);
-            }
-        }
+        addField(solr_property, value);
     }
 
     /**
@@ -229,7 +147,10 @@ public class SolrRecord implements Serializable {
      * @param value
      */
     public void setField(String solr_property, String value) {
-        setFieldTruncated(solr_property, value, getMaxLength(solr_property));
+        String adjusted = adjust(solr_property, value);
+        if (adjusted != null && isAllowedtoAdd(solr_property, adjusted)) {
+            doc.setField(solr_property, adjusted);
+        }
     }
 
     /**
@@ -237,14 +158,41 @@ public class SolrRecord implements Serializable {
      * 
      * @param solr_property
      * @param value
-     * @param truncateTo
+     * @param truncateTo ignored after deprecation.
+     * @deprecated superceeded by the {@link #contentAdjusters} mechanism. Use {@link #setField(String, String)} instead.
      */
     public void setFieldTruncated(String solr_property, String value, int truncateTo) {
-        value = sanitizeString(value, truncateTo);
-        if (value != null && !value.isEmpty())
-            doc.setField(solr_property, value);
+        setField(solr_property, value);
     }
     
+    /**
+     * Adjusts the value using {@link #contentAdjusters} or {@link #defaultContentAdjuster}.
+     * If the value is to be ignored, null is returned.
+     * @param solrField the destination field name in the SolrDocument.
+     * @param value the field value.
+     * @return the value adjusted according to setup or null if the value should be ignored.
+     */
+    String adjust(String solrField, String value) {
+        return contentAdjusters.getOrDefault(solrField, defaultContentAdjuster).apply(value);
+    }
+
+    /**
+     * @param solrField the destination field name in the SolrDocument.
+     * @param value used to check for duplicates.
+     * @return true if it is acceptable to add a(nother) value to the given field.
+     */
+    boolean isAllowedtoAdd(String solrField, String value) {
+        int maxValues = contentAdjusters.getOrDefault(solrField, defaultContentAdjuster).getMaxValues();
+        if (maxValues == -1) {
+            return true;
+        }
+        if (maxValues == 0) {
+            return false;
+        }
+        Collection<Object> values = doc.getFieldValues(solrField);
+        return values == null || (values.size() < maxValues && !values.contains(value));
+    }
+
     /**
      * Like add, but also allows these values to merge with those in the index already.
      * 
@@ -252,11 +200,13 @@ public class SolrRecord implements Serializable {
      * @param value
      */
     public void mergeField( String solr_property, String value ) {
-        if (value == null || value.isEmpty()) {
+        String adjusted = adjust(solr_property, value);
+        if (adjusted == null) {
             return;
         }
+        // Noto: No check for maxValues!
         Map<String, String> operation = new HashMap<String, String>();
-        operation.put("add", value );
+        operation.put("add", adjusted );
         doc.addField(solr_property, operation);
     }
 

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecord.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecord.java
@@ -55,12 +55,14 @@ public class SolrRecord implements Serializable {
     /**
      * field name -> function map for adjusting content length, correct UTF-8 problems etc.
      */
-    private final Map<String, FieldAdjuster> contentAdjusters;
+    // Marked as transient: SolrRecord content should not be changed after serialization
+    private transient Map<String, FieldAdjuster> contentAdjusters;
     /**
      * If there is no contentAdjuster available for a given field from {@link #contentAdjusters},
      * the defaultContentAdjuster is used.
      */
-    private final FieldAdjuster defaultContentAdjuster;
+    // Marked as transient: SolrRecord content should not be changed after serialization
+    private transient FieldAdjuster defaultContentAdjuster;
 
     public SolrRecord(Map<String, FieldAdjuster> contentAdjusters, FieldAdjuster defaultcontentAdjuster) {
         this.contentAdjusters = contentAdjusters;
@@ -99,7 +101,8 @@ public class SolrRecord implements Serializable {
                 s -> SolrRecordFactory.DEFAULT_MAX_LENGTH < 0 || s == null ||
                      s.length() < SolrRecordFactory.DEFAULT_MAX_LENGTH ?
                         s :
-                        s.substring(0, SolrRecordFactory.DEFAULT_MAX_LENGTH)
+                        s.substring(0, SolrRecordFactory.DEFAULT_MAX_LENGTH),
+                "maxLength=" + SolrRecordFactory.DEFAULT_MAX_LENGTH
         );
     }
 

--- a/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecordFactory.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/solr/SolrRecordFactory.java
@@ -24,14 +24,22 @@ package uk.bl.wa.solr;
  * #L%
  */
 
-import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.typesafe.config.Config;
 import org.archive.io.ArchiveRecordHeader;
+import uk.bl.wa.util.Instrument;
 
-import java.util.HashMap;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.*;
+import java.util.Collections;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Config supporting factory for {@link SolrRecord}, making it possible to specify limits on Solr fields.
@@ -39,50 +47,169 @@ import java.util.Map;
 public class SolrRecordFactory {
     private static Logger log = LoggerFactory.getLogger(SolrRecordFactory.class);
 
-    public static final String KEY_DEFAULT_MAX = "warc.solr.field_setup.default_max_length";
+    public static final String KEY_DEFAULT_ADJUSTER = "warc.solr.field_setup.default";
+    public static final String KEY_DEFAULT_MAX = "warc.solr.field_setup.default_max_length"; // Deprecated
     public static final String KEY_FIELD_LIST = "warc.solr.field_setup.fields";
-    public static final String KEY_MAX = "max_length";
+
+    public static final String KEY_MAX_LENGTH = "max_length";
+    public static final String KEY_MAX_VALUES = "max_values";
+    public static final String KEY_SANITIZE_UTF8 = "sanitize_utf8";
+    public static final String KEY_REMOVE_CONTROL_CHARACTERS = "remove_control_characters";
+    public static final String KEY_NORMALISE_WHITESPACE = "normalise_whitespace";
 
     public static final int DEFAULT_MAX_LENGTH = -1; // -1 = no limit
+    public static final int DEFAULT_MAX_VALUES = -1; // -1 = no limit
+    public static final boolean DEFAULT_SANITIZE_UTF8 = true;
+    public static final boolean DEFAULT_REMOVE_CONTROL_CHARACTERS = true;
+    public static final boolean DEFAULT_NORMALISE_WHITESPACE = true;
 
-    private final int defaultMax;
-    private final HashMap<String, Integer> maxLengths = new HashMap<>(); // Explicit HashMap as it is Serializable
+    private final FieldAdjuster defaultContentAdjuster;
+    private final Map<String, FieldAdjuster> contentAdjusters;
+
+    /**
+     * Factory using the default values for content adjusters.
+     */
+    public static final SolrRecordFactory DEFAULT_FACTORY = createFactory(null);
 
     public static SolrRecordFactory createFactory(Config config) {
         return new SolrRecordFactory(config);
     }
 
     private SolrRecordFactory(Config config) {
-        defaultMax = config != null && config.hasPath(KEY_DEFAULT_MAX) ?
-                config.getInt(KEY_DEFAULT_MAX) : DEFAULT_MAX_LENGTH;
-        StringBuilder sb = new StringBuilder();
-        if (config != null && config.hasPath(KEY_FIELD_LIST)) {
-            for (Map.Entry<String, ConfigValue> cv : config.getObject(KEY_FIELD_LIST).entrySet()) {
-                String field = cv.getKey();
-                String maxKey = KEY_FIELD_LIST + "." + field + "." + KEY_MAX;
-                if (config.hasPath(maxKey)) {
-                    long max = config.getBytes(KEY_FIELD_LIST + "." + field + "." + KEY_MAX);
-                    if (max > Integer.MAX_VALUE) {
-                        log.error("The limit " + max + " for field " + field + " exceeds Integer.MAX_VALUE");
-                        continue;
-                    }
-                    if (sb.length() > 0) {
-                        sb.append(", ");
-                    }
-                    sb.append(field).append("=").append(max);
-                    maxLengths.put(field, (int) max);
-                }
-            }
+        // Compensate for old setups
+        if (config != null && (!config.hasPath(KEY_DEFAULT_ADJUSTER) && config.hasPath(KEY_DEFAULT_MAX))) {
+            // This is an old config, which has a default_max. We copy the default_max to the new position
+            config = config.withValue(KEY_DEFAULT_ADJUSTER + "." + KEY_MAX_LENGTH,
+                                      ConfigValueFactory.fromAnyRef(config.getBytes(KEY_DEFAULT_MAX)));
         }
-        log.info("Created SolrRecordFactory(defaultMaxLength=" + defaultMax + ", maxLengths=[" + sb + "])");
+        defaultContentAdjuster = createContentAdjuster(
+                config == null || !config.hasPath(KEY_DEFAULT_MAX) ? null : config.getConfig(KEY_DEFAULT_MAX));
+        if (config == null || !config.hasPath(KEY_FIELD_LIST)) {
+            contentAdjusters = Collections.emptyMap();
+        } else {
+            Config fieldConfigs = config.getConfig(KEY_FIELD_LIST);
+            contentAdjusters = fieldConfigs.entrySet().stream().collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> createContentAdjuster(fieldConfigs.getConfig(e.getKey()))));
+        }
+        log.info("Created " + this);
     }
 
     public SolrRecord createRecord() {
-        return new SolrRecord(defaultMax, maxLengths);
+        return new SolrRecord(contentAdjusters, defaultContentAdjuster);
     }
 
     public SolrRecord createRecord(String filename, ArchiveRecordHeader header) {
-        return new SolrRecord(defaultMax, maxLengths, filename, header);
+        return new SolrRecord(contentAdjusters, defaultContentAdjuster, filename, header);
     }
 
+    /**
+     * Create a pipeline of content adjusters based on the given configuration and the DEFAULT_*-fields in the factory.
+     * @param config the configuration with KEY_*-entries immediately available. Config can be null
+     * @return a pipeline of content adjusters.
+     *         Returning null from {@link UnaryOperator#apply(Object)} means that the content should be discarded.
+     */
+    private FieldAdjuster createContentAdjuster(Config config) {
+
+        Function<String, String> pipeline = s -> s == null ? "" : s;
+
+        // Max values for the given field
+        int maxValues = config != null && config.hasPath(KEY_MAX_VALUES) ?
+                Math.toIntExact(config.getBytes(KEY_MAX_VALUES)) :
+                DEFAULT_MAX_VALUES;
+        if (maxValues == 0) {
+            return new FieldAdjuster(0, s -> null); // Early termination: Don't create a full chain when we always discard the result
+        }
+
+        // Max content length in characters
+        int maxLength = config != null && config.hasPath(KEY_MAX_LENGTH) ?
+                Math.toIntExact(config.getBytes(KEY_MAX_LENGTH)) :
+                DEFAULT_MAX_LENGTH;
+        if (maxLength == 0) {
+            return new FieldAdjuster(maxValues, s -> null); // Early termination: Don't create a full chain when we always discard the result
+        }
+        if (maxLength != -1) {
+            pipeline = pipeline.andThen( s -> s.length() <= maxLength ? s : s.substring(0, maxLength));
+
+        }
+
+        // Remove control characters
+        if (isEnabled(config, KEY_REMOVE_CONTROL_CHARACTERS, DEFAULT_REMOVE_CONTROL_CHARACTERS)) {
+            pipeline = pipeline.andThen(s -> CNTRL_PATTERN.matcher(s).replaceAll(""));
+        }
+
+        // Sanitize UTF-8
+        if (isEnabled(config, KEY_SANITIZE_UTF8, DEFAULT_SANITIZE_UTF8)) {
+            pipeline = pipeline.andThen(this::sanitiseUTF8);
+        }
+
+        // Normalise white space
+        if (isEnabled(config, KEY_NORMALISE_WHITESPACE, DEFAULT_NORMALISE_WHITESPACE)) {
+            pipeline = pipeline.andThen(s -> SPACE_PATTERN.matcher(s.trim()).replaceAll(" "));
+        }
+
+        // Don't index if empty
+        Function<String, String> frozen = pipeline.andThen(s -> s.isEmpty() ? null : s);
+
+        // Instrument the lambda for statistical purposes and return it
+        Function<String, String> instrumented = s -> {
+            final long start = System.nanoTime();
+            try {
+                return frozen.apply(s);
+            } finally {
+                Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#solrdocCreation",
+                                   "SolrRecord.adjustContent#total", start);
+            }
+        };
+
+        return new FieldAdjuster(maxValues, instrumented);
+    }
+    private static final Pattern SPACE_PATTERN = Pattern.compile("\\p{Space}");
+    private static final Pattern CNTRL_PATTERN = Pattern.compile("\\p{Cntrl}");
+
+    private boolean isEnabled(Config config, String key, boolean defaultValue) {
+        return config != null && config.hasPath(key) ? config.getBoolean(key) : defaultValue;
+    }
+
+    /**
+     * Aim to prevent "Invalid UTF-8 character 0xfffe" slipping into the text
+     * payload.
+     *
+     * The encodes and decodes a String that may not be UTF-8 compliant as
+     * UTF-8. Any dodgy characters are replaced.
+     *
+     * @param value
+     * @return
+     * @throws CharacterCodingException
+     */
+    // It would be nice to re-use the encoder & decoder, but they are not Thread-safe
+    private String sanitiseUTF8(String value) {
+        try {
+            // Take a string, map it to bytes as UTF-8:
+            CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
+            encoder.onMalformedInput(CodingErrorAction.REPLACE);
+            encoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
+            ByteBuffer bytes = encoder.encode(CharBuffer.wrap(value));
+            // Now decode back again:
+            CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+            decoder.onMalformedInput(CodingErrorAction.REPLACE);
+            decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
+            return decoder.decode(bytes).toString();
+        } catch (CharacterCodingException e) {
+            throw new RuntimeException(
+                    "Character coding exception for '" +
+                    (value.length() > 200 ? value.substring(0, 197) + "..." : value) + "'",
+                    e);
+        }
+    }
+
+    // TODO: Add proper toString()
+
+    @Override
+    public String toString() {
+        return "SolrRecordFactory{" +
+               "defaultContentAdjuster=" + defaultContentAdjuster +
+               ", contentAdjusters=" + contentAdjusters +
+               '}';
+    }
 }

--- a/warc-indexer/src/main/java/uk/bl/wa/util/RegexpReplacer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/RegexpReplacer.java
@@ -1,0 +1,107 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package uk.bl.wa.util;
+
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Generic String replacer that uses 0 or more Patterns + Replacements for processing the given Strings.
+ *
+ * Uses the Typesafe {@link Config} framework for setup.
+ */
+public class RegexpReplacer implements UnaryOperator<String> {
+    private static Logger log = LoggerFactory.getLogger(RegexpReplacer.class );
+
+    public static final String PATTERN_KEY = "pattern";
+    public static final String REPLACEMENT_KEY = "replacement";
+
+    public final List<Replacer> replacers;
+
+    /**
+     * Create the list of pattern+replacements using the rules under the given key.
+     * The patterns should be stored with the key {@link #PATTERN_KEY} and the replacements with
+     * {@link #REPLACEMENT_KEY}. The rules will be applied using {@code Pattern.matcher(s).replaceAll}.
+     *
+     * The rules are taken from the path rulesPath. If there are no rules at the given path, an empty list of rules
+     * is created.
+     * @param config configuration possibly containing rules for replacement.
+     * @param rulesPath the path in config to read the rules from. For URL-rewriting this will be
+     *                  {@code myconfig.getConfigList("warc.index.extract.url_rewrite}
+     */
+    public RegexpReplacer(Config config, String rulesPath) {
+        this(config.hasPath(rulesPath) ? config.getConfigList(rulesPath) : null);
+    }
+
+    /**
+     * Create the list of pattern+replacements using the given rules.
+     * The patterns should be stored with the key {@link #PATTERN_KEY} and the replacements with
+     * {@link #REPLACEMENT_KEY}. The rules will be applied using {@code Pattern.matcher(s).replaceAll}.
+     *
+     * The rules are normally derived from the overall configuration using
+     * {@code myconfig.getConfigList("warc.index.extract.url_rewrite}.
+     * @param rules a list of rules to apply. This can be empty or null.
+     */
+    public RegexpReplacer(List<? extends Config> rules) {
+        log.info("Creating RegexpReplacer with {} rules", rules == null ? 0 : rules.size());
+        replacers = rules == null ? Collections.emptyList() :
+                rules.stream().map(Replacer::new).collect(Collectors.toList());
+    }
+
+    /**
+     * Apply the given pattern+replacement rules to the given String.
+     * @param s input String.
+     * @return the input string after the chain of pattern+replacements has been applied.
+     */
+    @Override
+    public String apply(String s) {
+        for (Replacer replacer: replacers) {
+            s = replacer.apply(s);
+        }
+        return s;
+    }
+
+    /**
+     * Holds compiled Pattern and corresponding replacement.
+     */
+    private static class Replacer implements UnaryOperator<String> {
+        private final Pattern pattern;
+        private final String replacement;
+
+        public Replacer(Config config) {
+            this(config.getString(PATTERN_KEY), config.getString(REPLACEMENT_KEY));
+        }
+        public Replacer(String pattern, String replacement) {
+            this.pattern = Pattern.compile(pattern);
+            this.replacement = replacement;
+            if (replacement == null) {
+                throw new IllegalArgumentException(
+                        "The replacement for pattern '" + pattern + "' was null, which is not supported");
+            }
+        }
+
+        @Override
+        public String apply(String s) {
+            return pattern.matcher(s).replaceAll(replacement);
+        }
+    }
+}

--- a/warc-indexer/src/main/java/uk/bl/wa/util/RegexpReplacer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/util/RegexpReplacer.java
@@ -62,7 +62,7 @@ public class RegexpReplacer implements UnaryOperator<String> {
      * @param rules a list of rules to apply. This can be empty or null.
      */
     public RegexpReplacer(List<? extends Config> rules) {
-        log.info("Creating RegexpReplacer with {} rules", rules == null ? 0 : rules.size());
+        log.debug("Creating RegexpReplacer with {} rules", rules == null ? 0 : rules.size());
         replacers = rules == null ? Collections.emptyList() :
                 rules.stream().map(Replacer::new).collect(Collectors.toList());
     }
@@ -78,6 +78,11 @@ public class RegexpReplacer implements UnaryOperator<String> {
             s = replacer.apply(s);
         }
         return s;
+    }
+
+    @Override
+    public String toString() {
+        return "RegexpReplacer{" + replacers + "}";
     }
 
     /**
@@ -102,6 +107,11 @@ public class RegexpReplacer implements UnaryOperator<String> {
         @Override
         public String apply(String s) {
             return pattern.matcher(s).replaceAll(replacement);
+        }
+
+        @Override
+        public String toString() {
+            return "replace('" + pattern + "', '" + replacement + "')";
         }
     }
 }

--- a/warc-indexer/src/main/resources/reference.conf
+++ b/warc-indexer/src/main/resources/reference.conf
@@ -104,7 +104,8 @@
                 ],
    
                 # URLs to skip, e.g. ['robots.txt'] ???
-                "url_exclude" : [],
+                "url_exclude" : []
+
             },
             
             # Parameters relating to format identification:   
@@ -175,10 +176,61 @@
 
             # field-specific setup
             "field_setup" : {
+                # The default is used for the content of all SolrFields, unless overridden for any specific field in
+                # in field_setup.fields
+                "default" : {
+                    # The maximum number of values for this field. Extra values are discarded
+                    # -1 means no limit (practically 2 billion)
+                    # 0 disables the field in Solr. Note: This does not disable the warc-indexer processing overhead for the field content
+                    # Default is -1
+                    "max_values" : -1,
+                    # Text with more that this number of characters is truncated down to the max_length
+                    # -1 means no limit (practically 2 billion)
+                    # 0 disables the field in Solr. Note: This does not disable the warc-indexer processing overhead for the field content
+                    # Default is -1
+                    "max_length" : -1,
+                    # Custom rewrites of field content. This is effectively a chain of
+                    # Pattern.compile(pattern).matcher(content).replaceAll(replacement)
+                    "rewrites" : [
+#                        {
+#                            pattern: "",
+#                            replacement: ""
+#                        }
+                    ],
+                    # Ensures that the content can be represented as UTF-8 without exceptions.
+                    # History shows that some content using high order characters can trigger the construction of
+                    # illegal UTF-8, leading to exceptions during indexing.
+                    # Default: true (highly recommended)
+                    "sanitize_utf8" : true,
+                    # Removes ASCII control characters from the content
+                    # Default: true
+                    "remove_control_characters" : true,
+                    # Remove leading and trailing space characters
+                    # Collapse multiple subsequent spaces down to a single space
+                    # Default: true
+                    "normalise_whitespace" : true
+                },
+                # Deprecated: Use field_setup.default.max_length instead
                 "default_max_length" : -1,
+                # keys are field names, values follows the pattern from field_setup.default
                 "fields" : {
                     "url" :      { "max_length" : 2048 }, # de facto max length for GET URLs
-                    "url_norm" : { "max_length" : 2048 },
+                    "url_norm" : {
+                        "max_length" : 2048,
+                        "rewrites" : [
+                            {
+                                # Heritrix 3.4.0-IIPC-NAS-SNAPSHOT-2019-11-20T10:01:48Z parses img srcset wrong,
+                                # attempting to follow and harvest image links such as "http://example.com/foo.jpg 720w".
+                                # Some webservers ignore trailing terms and provide the same response as for "http://example.com/foo.jpg".
+                                # However, the WARC-Target-URI for the resource is unchanged at "http://example.com/foo.jpg%20720w"
+                                # which works poorly for playback.
+
+                                # This rule compensates for that problem so that the indexed URL will be "http://example.com/foo.jpg"
+                                pattern: "^(.*)(%20[0-9.]+[wx])$",
+                                replacement: "$1"
+                            }
+                        ]
+                    },
                     "links" :    { "max_length" : 2048 },
                     "content" :  { "max_length" : 512K }, # Same as tika.max_text_length
                 },

--- a/warc-indexer/src/test/java/uk/bl/wa/indexer/WARCIndexerCommandTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/indexer/WARCIndexerCommandTest.java
@@ -44,8 +44,16 @@ public class WARCIndexerCommandTest {
     // Local WARC that triggered long exit for the JVM after processing has finished
     @Test
     public void testSBWARC() throws NoSuchAlgorithmException, TransformerException, IOException {
-        testWARC("/home/te/projects/measurements/solrcloud/config3.conf",
+        testWARC("/home/te/projects/netarkivet/warc-indexer-conf-rewrite-url.conf",
                 "/home/te/projects/measurements/solrcloud/169568-178-20121224135757-00257-sb-prod-har-006.statsbiblioteket.dk.arc.gz");
+        Instrument.log(true);
+    }
+
+    // Local WARC that contains problematic harvests of srcSet
+    @Test
+    public void testSBWARCSrcSet() throws NoSuchAlgorithmException, TransformerException, IOException {
+        testWARC("/home/te/projects/measurements/solrcloud/config3.conf",
+                "/home/te/projects/netarkivet/354485-265-20210102130246631-00000-sb-prod-har-002.statsbiblioteket.dk.warc.gz");
         Instrument.log(true);
     }
 

--- a/warc-indexer/src/test/java/uk/bl/wa/solr/SolrRecordFactoryTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/solr/SolrRecordFactoryTest.java
@@ -51,6 +51,7 @@ public class SolrRecordFactoryTest {
     @Test
     public void testBasicFactorySetup() {
         final String KEY_URL_MAX_LENGTH = "warc.solr.field_setup.fields.url.max_length";
+        final String KEY_URL_NORM = "warc.solr.field_setup.fields.url_norm.rewrites";
 
         URL ref = Thread.currentThread().getContextClassLoader().getResource("reference.conf");
         assertNotNull("The config reference.conf should exist", ref);
@@ -58,14 +59,16 @@ public class SolrRecordFactoryTest {
         Config conf = ConfigFactory.parseFile(configFilePath);
         assertTrue("Max for url field should be specified with key " + KEY_URL_MAX_LENGTH,
                    conf.hasPath(KEY_URL_MAX_LENGTH));
+        assertTrue("There should be a setup for url_norm.rewrites", conf.hasPath(KEY_URL_NORM));
         SolrRecordFactory factory = SolrRecordFactory.createFactory(conf);
 
+        // Check max_length handling
         {
             SolrRecord record = factory.createRecord();
             final String FAKE_URL = "short";
-            record.addField("url", FAKE_URL);
+            record.addField(SolrFields.SOLR_URL, FAKE_URL);
             assertEquals("The length of the url field with a short String should be unchanged",
-                         FAKE_URL.length(), record.getFieldValue("url").toString().length());
+                         FAKE_URL.length(), record.getFieldValue(SolrFields.SOLR_URL).toString().length());
         }
         {
             SolrRecord record = factory.createRecord();
@@ -74,10 +77,29 @@ public class SolrRecordFactoryTest {
             for (int i = 0 ; i < 2500 ; i++) {
                 fakeURL.append("O");
             }
-            record.addField("url", fakeURL.toString());
+            record.addField(SolrFields.SOLR_URL, fakeURL.toString());
             assertEquals("The length of the url field with a huge String should be trimmed",
                          conf.getBytes(KEY_URL_MAX_LENGTH).intValue(),
-                         record.getFieldValue("url").toString().length());
+                         record.getFieldValue(SolrFields.SOLR_URL).toString().length());
         }
+
+        // Check url_norm rewrite
+        final String BASE_URL = "http://example.com/foo.png";
+        final String PROBLEM_URL = "http://example.com/foo.png%201080w";
+        {
+            SolrRecord record = factory.createRecord();
+            record.addField(SolrFields.SOLR_URL_NORMALISED, BASE_URL);
+            assertEquals("Non-problematic URL should be stored unchanged in url_norm",
+                         BASE_URL,
+                         record.getFieldValue(SolrFields.SOLR_URL_NORMALISED).toString());
+        }
+        {
+            SolrRecord record = factory.createRecord();
+            record.addField(SolrFields.SOLR_URL_NORMALISED, PROBLEM_URL);
+            assertEquals("Problematic URL should be adjusted to base URL in url_norm",
+                         BASE_URL,
+                         record.getFieldValue(SolrFields.SOLR_URL_NORMALISED).toString());
+        }
+
     }
 }


### PR DESCRIPTION
Clean up the existing content adjustment mechanism for `SolrDocument` (max content length, UTF8 sanitising, white space normalisation) and add optional regexp-based replacement rules.

This closes #256 and makes it easier to implement #152