### PR TITLE
Enable text output when using Elasticsearch, mirroring Solr behaviour

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -153,8 +153,8 @@ public class WARCIndexerCommand {
             System.exit( 0 );
         }
 
-        // Check if the text field is required in the XML output
-        final boolean isTextRequired = line.hasOption("t") || line.hasOption("s");
+        // Check if the text field is required for the output (explicit (-t), Elasticsearch or Solr)
+        final boolean isTextRequired = line.hasOption("t") || line.hasOption("s") || line.hasOption("e");
 
         final boolean slashPages = line.hasOption("r");
 


### PR DESCRIPTION
Currently the user needs to explicitly set the `-t` command line option to have warc-indexer produce freetext when using Elasticsearch. Since this is automatically enabled when using Solr, it makes sense to also auto-enable it for Elasticsearch.

A bit broader: Why is this an opt-in? Shouldn't text be the default, with the possibility of opting out?