### PR TITLE
Remove extra .jar from the produced with-dependencies JAR

### DIFF
--- a/warc-indexer/pom.xml
+++ b/warc-indexer/pom.xml
@@ -33,7 +33,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.3</version>
                 <configuration>
-                    <finalName>${project.build.finalName}-jar-with-dependencies.jar</finalName>
+                    <finalName>${project.build.finalName}-jar-with-dependencies</finalName>
                     <filters>
                         <filter>
                             <artifact>*:*</artifact>


### PR DESCRIPTION
Trivial one-liner fix: The old `pom.xml` for warc-indexer produced a JAR with double file extension: `warc-indexer-3.2.0-SNAPSHOT-jar-with-dependencies.jar.jar`.