### PR TITLE
Flush buffered documents when writing documents to file

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/delivery/BufferedDocumentConsumer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/delivery/BufferedDocumentConsumer.java
@@ -121,7 +121,7 @@ public abstract class BufferedDocumentConsumer implements DocumentConsumer {
             return;
         }
 
-        log.debug("Flushing {} documents", docs);
+        log.debug("Flushing {} documents", docs.size());
         final long start = System.nanoTime();
         performFlush(Collections.unmodifiableList(docs));
         Instrument.timeRel(

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/delivery/DocumentConsumer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/delivery/DocumentConsumer.java
@@ -54,7 +54,8 @@ public interface DocumentConsumer extends Closeable {
     void add(SolrRecord solrRecord) throws IOException;
 
     /**
-     * Perform an explicit flush of buffered documents.
+     * Perform an explicit flush of buffered documents. After this, all buffered documents should have been
+     * fully consumed, i.e. send to Solr/Elasticsearch or written to the file system.
      * @throws IOException if the flush could not be completed.
      */
     void flush() throws IOException;
@@ -87,6 +88,7 @@ public interface DocumentConsumer extends Closeable {
 
     /**
      * Signals that the processing of a WARC file has finished.
+     * DocumentConsumer implementations are responsible for calling {@link #flush()} if needed.
      * @throws IOException if the warc end signal caused problems.
      */
     default void endWARC() throws IOException {

--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/delivery/SingleFileDocumentConsumer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/delivery/SingleFileDocumentConsumer.java
@@ -96,6 +96,9 @@ public class SingleFileDocumentConsumer extends BufferedDocumentConsumer {
         for (SolrRecord record: docs) {
             record.writeXml(out);
         }
+        // "</add>" is not appended, as it only makes sense on close, so this is not strictly correct behaviour
+        // as defined in DocumentConsumer#flush. Not much to do about that.
+        out.flush();
     }
 
     @Override
@@ -125,6 +128,7 @@ public class SingleFileDocumentConsumer extends BufferedDocumentConsumer {
         if (out == null) {
             return;
         }
+        flush(); // Ensure all buffered documents are written
         out.write("</add>");
         out.flush();
         out.close();


### PR DESCRIPTION
When the documents generated by warc-indexer are written to a single file (for debugging or later batch-index into a Solr installation), a flush is missing, triggering an exception and potentially causing a truncated output.

This pull request adds a flush in the proper place and makes some of the JavaDocs for the `DocumentConsumer` more explicit on what will happen.