### PR TITLE
Fix build for Maven 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
       <repository>
          <id>version99</id>
          <!-- highly available repository serving empty artifacts -->
-         <url>http://version99.qos.ch/</url>
+         <url>https://version99.qos.ch/</url>
       </repository>
 
       <repository>


### PR DESCRIPTION
As described in #267, Maven 3.8.1 no longer accepts `http`-repos, but requires `https`. webarchive-discovery only uses `http` for the version99 repo, so fixing it is trivial (just insert a `s`).