### PR TITLE
Add support for resource WARC records (produced by e.g. warcit)

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -651,13 +651,11 @@ public class WARCIndexer {
     private HTTPHeader processWARCHTTPHeaders(
             ArchiveRecord record, ArchiveRecordHeader warcHeader, String targetUrl, SolrRecord solr)
             throws IOException {
-        // There are not always headers! The code should check first.
+        // There are not always headers!
         HTTPHeader httpHeaders = new HTTPHeader();
-        if (("" + warcHeader.getHeaderValue("WARC-Type")).equals("resource") &&
-            ("" + warcHeader.getHeaderValue("WARC-Source-URI")).startsWith("file:/")) {
-            log.debug("Skipping HTTP header extraction as the record is a resource from the file system " +
-                      "(probably produced by warcit): '" + targetUrl + "'");
-            httpHeaders.setHttpStatus("200");
+        if (("" + warcHeader.getHeaderValue("WARC-Type")).equals("resource")) {
+            log.debug("Skipping HTTP header extraction as the record is a resource: '" + targetUrl + "'");
+            httpHeaders.setHttpStatus("200"); // Cheating a bit here for tool compatibility
             return httpHeaders;
         }
 

--- a/warc-indexer/src/main/resources/reference.conf
+++ b/warc-indexer/src/main/resources/reference.conf
@@ -88,7 +88,7 @@
                 
                 # Restrict record types:
                 "record_type_include" : [
-                    response, revisit
+                    response, resource, revisit
                 ],
                 
                 # Restrict response codes:

--- a/warc-indexer/src/test/java/uk/bl/wa/indexer/WARCIndexerCommandTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/indexer/WARCIndexerCommandTest.java
@@ -36,7 +36,9 @@ import java.security.NoSuchAlgorithmException;
 import static org.junit.Assert.*;
 
 /**
- * Helper class for debugging warc-indexer with local canfigs & WARCs.
+ * Helper class for debugging warc-indexer with local configs & WARCs.
+ * The class is bening as it checks for file existence, so it becomes a no-op for people that does
+ * not have the test files.
  */
 public class WARCIndexerCommandTest {
     private static Logger log = LoggerFactory.getLogger(WARCIndexerCommandTest.class);
@@ -54,6 +56,14 @@ public class WARCIndexerCommandTest {
     public void testKBWARCExif() throws NoSuchAlgorithmException, TransformerException, IOException {
         testWARC("/home/te/projects/webarchive-discovery/config3_toes.conf",
                 "/home/te/projects/webarchive-discovery/katte_gps.warc");
+        Instrument.log(true);
+    }
+
+    // warcit package from https://github.com/netarchivesuite/solrwayback/issues/192
+    @Test
+    public void testWarcit() throws NoSuchAlgorithmException, TransformerException, IOException {
+        testWARC("/home/te/projects/webarchive-discovery/config3_toes.conf",
+                "/home/te/projects/webarchive-discovery/20020308.warc.gz");
         Instrument.log(true);
     }
 


### PR DESCRIPTION
SolrWayback got the issue https://github.com/netarchivesuite/solrwayback/issues/192 about non-indexing of warcit WARCs. warcit WARCs are packed from the local filesystem and the individual records are of type `resource`. There were a few minor problems:

1. The default config did not include the `resource` type
2. Extraction of HTTP headers were attempted, but failed (naturally as there are none for local files). This meant that the HTTP status header was not set, so the record was discarded as invalid
3. There were no explicit mention of discarded records in the process log, so the summary at the end looked like everything went well

The 3 issues his are handled in this pull request.