### PR TITLE
Host links validation

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/analyser/payload/HTMLAnalyser.java
@@ -188,8 +188,7 @@ public class HTMLAnalyser extends AbstractPayloadAnalyser {
                 }
 
                 for(String hostLevel : uniqueHostLevels) {
-                    solr.addField(SolrFields.SOLR_LINKS_HOSTS_SURTS,
-                            SURT.toSURT(hostLevel));
+                    solr.addField(SolrFields.SOLR_LINKS_HOSTS_SURTS, SURT.toSURT(hostLevel));
                 }
             }
             if( this.extractLinkDomains ) {

--- a/warc-indexer/src/main/java/uk/bl/wa/extract/LinkExtractor.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/extract/LinkExtractor.java
@@ -51,9 +51,9 @@ public class LinkExtractor {
     public static final String MALFORMED_HOST = "malformed.host";
     
     /**
-     * 
-     * @param url
-     * @return
+     * Given an URL, extract the host and return it.
+     * @param url an uncontrolled String which might be a valid URL.
+     * @return the host or {@link #MALFORMED_HOST} if the host was malformed.
      */
     public static String extractHost(String url) {
         // Attempt to parse:
@@ -61,7 +61,8 @@ public class LinkExtractor {
             org.apache.commons.httpclient.URI uri = new org.apache.commons.httpclient.URI(url,false);
             // Extract domain:
             String host = uri.getHost();
-            if( host == null || !HOST_PATTERN.matcher(host).matches()) {
+            // RFC-952 and RFC-1123: 255 characters is the limit according to specs
+            if( host == null || !HOST_PATTERN.matcher(host).matches() || host.length() > 255) {
                 return MALFORMED_HOST;
             }
             return host;
@@ -72,7 +73,8 @@ public class LinkExtractor {
     }
     // Modified from
     // https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address/3824105#3824105
-    // We allow all letters eventhough only a-z are legal for analysis purposes
+    // We allow all letters even though only a-z are legal with the intention of later punycode-encoding
+    // This has no effect in extractHost as the Apache URI handler replaces non-ascii characters with '?'
     private static final Pattern HOST_PATTERN = Pattern.compile(
             "([\\p{L}\\d]|[\\p{L}\\d][\\p{L}\\d-]{0,61}[\\p{L}\\d])" +
             "([.]([\\p{L}\\d]|[\\p{L}\\d][\\p{L}\\d-]{0,61}[\\p{L}\\d]))*$");

--- a/warc-indexer/src/main/java/uk/bl/wa/extract/LinkExtractor.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/extract/LinkExtractor.java
@@ -32,6 +32,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.tika.metadata.Metadata;
 
@@ -55,21 +56,26 @@ public class LinkExtractor {
      * @return
      */
     public static String extractHost(String url) {
-        String host = "unknown.host";
-        org.apache.commons.httpclient.URI uri = null;
         // Attempt to parse:
         try {
-            uri = new org.apache.commons.httpclient.URI(url,false);
+            org.apache.commons.httpclient.URI uri = new org.apache.commons.httpclient.URI(url,false);
             // Extract domain:
-            host = uri.getHost();
-            if( host == null )
-                host = MALFORMED_HOST;
+            String host = uri.getHost();
+            if( host == null || !HOST_PATTERN.matcher(host).matches()) {
+                return MALFORMED_HOST;
+            }
+            return host;
         } catch ( Exception e ) {
             // Return a special hostname if parsing failed:
-            host = MALFORMED_HOST;
+            return MALFORMED_HOST;
         }
-        return host;
     }
+    // Modified from
+    // https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address/3824105#3824105
+    // We allow all letters eventhough only a-z are legal for analysis purposes
+    private static final Pattern HOST_PATTERN = Pattern.compile(
+            "([\\p{L}\\d]|[\\p{L}\\d][\\p{L}\\d-]{0,61}[\\p{L}\\d])" +
+            "([.]([\\p{L}\\d]|[\\p{L}\\d][\\p{L}\\d-]{0,61}[\\p{L}\\d]))*$");
     
     /**
      * 

--- a/warc-indexer/src/test/java/uk/bl/wa/extract/LinkExtractorTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/extract/LinkExtractorTest.java
@@ -47,6 +47,25 @@ public class LinkExtractorTest {
         testExtractPublicSuffixFromHost("parliament.uk", "parliament.uk");
     }
 
+    @Test
+    public void testExtractHost() {
+        final String[][] TESTS = new String[][]{
+                // url, host
+                {"http://foo.example.com/", "foo.example.com"},
+                {"http://87.com/", "87.com"},
+                {"http://a.com/", "a.com"},
+                {"http://b-a", "b-a"},
+//                {"http://æblegrød.dk", "æblegrød.dk"}, // TODO: While not a legal host, this should be extracted?
+
+                {"http://-a", LinkExtractor.MALFORMED_HOST},
+                {"http://abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcd.com", LinkExtractor.MALFORMED_HOST}, // 64 characters in a single part
+                {"http://foo.example.com&foo=bar", LinkExtractor.MALFORMED_HOST}
+        };
+        for (String[] test: TESTS) {
+            assertEquals(test[1], LinkExtractor.extractHost(test[0]));
+        };
+    }
+
     private void testExtractPublicSuffixFromHost(String host,
             String expectedResult) {
         String domain = LinkExtractor

--- a/warc-indexer/src/test/java/uk/bl/wa/extract/LinkExtractorTest.java
+++ b/warc-indexer/src/test/java/uk/bl/wa/extract/LinkExtractorTest.java
@@ -55,7 +55,7 @@ public class LinkExtractorTest {
                 {"http://87.com/", "87.com"},
                 {"http://a.com/", "a.com"},
                 {"http://b-a", "b-a"},
-//                {"http://æblegrød.dk", "æblegrød.dk"}, // TODO: While not a legal host, this should be extracted?
+//                {"http://æblegrød.dk", "æblegrød.dk"}, // TODO: Should this be converted to punycode?
 
                 {"http://-a", LinkExtractor.MALFORMED_HOST},
                 {"http://abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcd.com", LinkExtractor.MALFORMED_HOST}, // 64 characters in a single part

--- a/warc-indexer/src/test/resources/links_extract_illegals.html
+++ b/warc-indexer/src/test/resources/links_extract_illegals.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+    <title>Illegal links for testing host extraction resilience</title>
+</head>
+<body> <!-- HTML 4 style -->
+<h1>See HTMLAnalyserTest for test code</h1>
+    <ul>
+    <li><a href="http://valid.example.com">Valid</a></li>
+    <li><a href="http://example.com&arguments">Missing slash</a></li>
+    <li><a href="not a link at all">Not n URL</a></li>
+    <li><a href="uuid:123456-1234-1234-12345678">UUID</a></li>
+    <li><a href="">Empty link</a></li>
+    </ul>
+
+</body>
+</html>

--- a/warc-indexer/src/test/resources/links_extract_illegals.html
+++ b/warc-indexer/src/test/resources/links_extract_illegals.html
@@ -6,6 +6,7 @@
 <h1>See HTMLAnalyserTest for test code</h1>
     <ul>
     <li><a href="http://valid.example.com">Valid</a></li>
+    <li><a href="http://æblegrød.dk">Non-ascii letters</a></li>
     <li><a href="http://example.com&arguments">Missing slash</a></li>
     <li><a href="not a link at all">Not n URL</a></li>
     <li><a href="uuid:123456-1234-1234-12345678">UUID</a></li>


### PR DESCRIPTION
The host links extractor was too lenient, accepting things like `example.com&` and very long entries (see #281). This pull requests introduces better validation.