### PR TITLE
Remove default value for disable-commit CL parameter for issue #319

### DIFF
--- a/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommandOptions.java
+++ b/warc-indexer/src/main/java/uk/bl/wa/indexer/WARCIndexerCommandOptions.java
@@ -116,8 +116,8 @@ public class WARCIndexerCommandOptions {
     @Option(names = { "-b", "--batch" }, description = "Batch size for submissions.", defaultValue = "100")
     public Integer batchSize;
 
-    @Option(names = { "-d", "--disable_commit", "--disable-commit" }, description = "Disable client side commits (speeds up indexing at the cost of flush guarantee).", defaultValue = "false")
-    public boolean disableCommit;
+    @Option(names = { "-d", "--disable_commit", "--disable-commit" }, description = "Disable client side commits (speeds up indexing at the cost of flush guarantee).")
+    public Boolean disableCommit;
 
     // The input files:
     @Parameters(paramLabel = "FILE", description = "Input file that contains a list of WARCs to be processed.")


### PR DESCRIPTION
For #319 

The default value is removed from the command-line parameter but is still available in the class [BufferedDocumentConsumer.java](https://github.com/ukwa/webarchive-discovery/blob/master/warc-indexer/src/main/java/uk/bl/wa/indexer/delivery/BufferedDocumentConsumer.java#L64) where the document consumer is initialized.